### PR TITLE
Rust: add rust-toolchain and rustfmt

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# this file is here to prevent build breakages on arch
+edition = "2021"


### PR DESCRIPTION
Add rustfmt and rust-toolchain in an effort to simplify the work 