### PR TITLE
feat: Add install-files metadata to crates for packaging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --bin xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "zbus"
 version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,5 @@
 [workspace]
-members = [
-    "crates/scx_loader",
-    "crates/scxctl",
-]
+members = ["xtask/", "crates/*"]
 resolver = "2"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/scx_loader.svg)](https://crates.io/crates/scx_loader)
 [![Crates.io](https://img.shields.io/crates/v/scxctl.svg)](https://crates.io/crates/scxctl)
 
-`scx_loader` is a system daemon and DBus-based loader for [sched_ext](https://github.com/sched-ext/scx) schedulers.  
+`scx_loader` is a system daemon and DBus-based loader for [sched_ext](https://github.com/sched-ext/scx) schedulers.
 `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically.
 
 Both tools were originally part of the main `sched-ext/scx` repository and are now developed independently.
@@ -30,7 +30,7 @@ cargo install scx_loader
 cargo install scxctl
 ```
 
-The binaries will be installed in `~/.cargo/bin`.  
+The binaries will be installed in `~/.cargo/bin`.
 Ensure this directory is in your `PATH`:
 
 ```bash
@@ -63,7 +63,7 @@ sudo find target/release \
     -exec install -Dm755 -t /usr/bin/ {} +
 ```
 
-Make sure you have also installed the necessary configuration files. 
+Make sure you have also installed the necessary configuration files.
 
 ```bash
 sudo install -Dm644 services/scx_loader.service \
@@ -74,6 +74,29 @@ sudo install -Dm644 configs/org.scx.Loader.conf \
     -t /usr/share/dbus-1/system.d/
 sudo install -Dm644 configs/scx_loader.toml \
     /usr/share/scx_loader/config.toml
+```
+
+### 3. Install with xtask
+
+Alternatively, you can use `xtask` to install the required files:
+
+```bash
+cargo xtask install
+```
+
+### Environment Variables for xtask
+
+The `xtask install` command respects several environment variables for customizing installation paths, which is useful for packaging by distributions:
+
+- `VENDOR_PREFIX`: Overrides the default `/usr` prefix for installation paths. (e.g., `/usr/local`)
+- `VENDOR_DATADIR`: Overrides the default `/usr/share` for data files.
+- `VENDOR_SYSCONFDIR`: Overrides the default `/etc` for configuration files.
+- `VENDOR_LIBDIR`: Overrides the default `$VENDOR_PREFIX/lib` for library files.
+
+Additionally, the `--destdir` flag can be used with `xtask install` to create package:
+
+```bash
+cargo xtask install --destdir $pkgdir
 ```
 ---
 
@@ -143,8 +166,8 @@ See: [scxctl](crates/scxctl/README.md)
 
 ## 🤝 Contributing
 
-Pull requests and discussions are welcome!  
-Follow Rust coding conventions and include descriptive commit messages.  
+Pull requests and discussions are welcome!
+Follow Rust coding conventions and include descriptive commit messages.
 Bug reports and proposals can be submitted in the [scx-tools issue tracker](https://github.com/sched-ext/scx-loader/issues).
 
 ---

--- a/crates/scx_loader/Cargo.toml
+++ b/crates/scx_loader/Cargo.toml
@@ -28,5 +28,9 @@ path = "src/lib.rs"
 name = "scx_loader"
 path = "src/main.rs"
 
-[lints.clippy]
-not_unsafe_ptr_arg_deref = "allow"
+[package.metadata.install-files]
+# [verbose name] -> { target = "src location", dest = "destination with annotated env vars" }
+dbus-policy = { target = "configs/org.scx.Loader.conf", dest = "$datadir/dbus-1/system.d/org.scx.Loader.conf" }
+example-config = { target = "configs/scx_loader.toml", dest = "$datadir/scx_loader/config.toml" }
+dbus-service = { target = "services/org.scx.Loader.service", dest = "$datadir/dbus-1/system-services/org.scx.Loader.service" }
+systemd-service = { target = "services/scx_loader.service", dest = "$libdir/systemd/system/scx_loader.service" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.65"
+clap = { version = "4.5.28", features = ["derive"] }
+serde = { version = "1.0.215", features = ["derive"] }
+toml = "0.8.19"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Deserialize;
+
+#[derive(Parser)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Parser)]
+enum Command {
+    Install {
+        #[clap(long)]
+        destdir: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    #[serde(rename = "install-files")]
+    install_files: HashMap<String, InstallConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallConfig {
+    target: String,
+    dest: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Package {
+    metadata: Option<Metadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CrateCargo {
+    package: Package,
+}
+
+#[derive(Debug)]
+struct DistConfig {
+    prefix: PathBuf,
+    datadir: PathBuf,
+    sysconfdir: PathBuf,
+    libdir: PathBuf,
+}
+
+impl DistConfig {
+    fn new() -> Self {
+        let prefix = env::var("VENDOR_PREFIX").unwrap_or_else(|_| "/usr".to_owned());
+        let datadir = env::var("VENDOR_DATADIR").unwrap_or_else(|_| "/usr/share".to_owned());
+        let sysconfdir = env::var("VENDOR_SYSCONFDIR").unwrap_or_else(|_| "/etc".to_owned());
+        let libdir = env::var("VENDOR_LIBDIR").unwrap_or_else(|_| format!("{prefix}/lib"));
+
+        Self {
+            prefix: prefix.into(),
+            datadir: datadir.into(),
+            sysconfdir: sysconfdir.into(),
+            libdir: libdir.into(),
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Install { destdir } => {
+            let destdir = destdir.as_deref();
+            install_files(destdir)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn install_files(destdir: Option<&Path>) -> Result<()> {
+    let workspace_path = workspace_path();
+    println!("Installing config files...");
+
+    let entries = fs::read_dir(workspace_path.join("crates"))
+        .expect("Failed to read directory!")
+        .flatten()
+        .map(|x| x.path())
+        .filter(|x| x.is_dir());
+
+    for entry_path in entries {
+        let crate_path = entry_path.join("Cargo.toml");
+        if !crate_path.exists() {
+            continue;
+        }
+        let crate_cargo = parse_metadata(&entry_path)?;
+        if let Some(install_configs) = crate_cargo.package.metadata.map(|x| x.install_files) {
+            install_crate_files(install_configs, destdir)?;
+        }
+    }
+    Ok(())
+}
+
+fn install_crate_files(
+    install_configs: HashMap<String, InstallConfig>,
+    destdir: Option<&Path>,
+) -> Result<()> {
+    let workspace_path = workspace_path();
+
+    let dist_config = DistConfig::new();
+
+    for (name, config) in install_configs {
+        let source_path = workspace_path.join(&config.target);
+        let dest_path = prepare_dest_path(destdir, &config.dest, &dist_config);
+        println!(
+            "Installing '{name}' from '{}' to '{}'",
+            source_path.display(),
+            dest_path.display()
+        );
+
+        if let Some(parent) = dest_path.parent() {
+            fs::create_dir_all(parent).context("Failed to create directories")?;
+        }
+        fs::copy(&source_path, &dest_path)?;
+    }
+
+    Ok(())
+}
+
+fn parse_metadata(crate_path: &Path) -> Result<CrateCargo> {
+    let crate_cargo_path = crate_path.join("Cargo.toml");
+    let file_content = fs::read_to_string(crate_cargo_path)?;
+    Ok(toml::from_str(&file_content)?)
+}
+
+fn prepare_dest_path(
+    destdir: Option<&Path>,
+    dest_path: &str,
+    defined_paths: &DistConfig,
+) -> PathBuf {
+    let mut dest_str =
+        dest_path.replace("$prefix", defined_paths.prefix.as_path().to_str().unwrap());
+    dest_str = dest_str.replace(
+        "$datadir",
+        defined_paths.datadir.as_path().to_str().unwrap(),
+    );
+    dest_str = dest_str.replace(
+        "$sysconfdir",
+        defined_paths.sysconfdir.as_path().to_str().unwrap(),
+    );
+    dest_str = dest_str.replace("$libdir", defined_paths.libdir.as_path().to_str().unwrap());
+
+    if let Some(destdir_path) = destdir {
+        destdir_path.join(dest_str.strip_prefix("/").unwrap_or(&dest_str))
+    } else {
+        dest_str.into()
+    }
+}
+
+fn workspace_path() -> PathBuf {
+    let manifest_dir =
+        env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_owned());
+    Path::new(&manifest_dir)
+        .parent()
+        .expect("Manifest isn't located in the project root")
+        .to_path_buf()
+}


### PR DESCRIPTION
xtask script should be used to the previous(stable rel) meson-based packaging setup.