### PR TITLE
scx-cosmos: update server mode

### DIFF
--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -75,7 +75,7 @@ auto_mode = ["-d"]
 gaming_mode = ["-c", "0", "-p", "0"]
 lowlatency_mode = ["-m", "performance", "-c", "0", "-p", "0", "-w"]
 powersave_mode = ["-m", "powersave", "-d", "-p", "5000"]
-server_mode = ["-a", "-s", "20000"]
+server_mode = ["-s", "20000"]
 
 [scheds.scx_beerland]
 auto_mode = []
@@ -142,7 +142,7 @@ The example configuration above shows how to set custom flags for different sche
     * Gaming mode: `-c 0 -p 0`
     * Low Latency mode: `-m performance -c 0 -p 0 -w`
     * Power Save mode: `-m powersave -d -p 5000`
-    * Server mode: `-a -s 20000`
+    * Server mode: `-s 20000`
 * For `scx_beerland`:
     * No custom flags are defined, so the default flags for each mode will be used.
 

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -250,7 +250,7 @@ fn get_default_scx_flags_for_mode(
             SchedMode::Gaming => vec!["-c", "0", "-p", "0"],
             SchedMode::LowLatency => vec!["-m", "performance", "-c", "0", "-p", "0", "-w"],
             SchedMode::PowerSave => vec!["-m", "powersave", "-d", "-p", "5000"],
-            SchedMode::Server => vec!["-a", "-s", "20000"],
+            SchedMode::Server => vec!["-s", "20000"],
             SchedMode::Auto => vec!["-d"],
         },
         // scx_rusty, scx_rustland, scx_beerland doesn't support any of these modes
@@ -330,7 +330,7 @@ auto_mode = ["-d"]
 gaming_mode = ["-c", "0", "-p", "0"]
 lowlatency_mode = ["-m", "performance", "-c", "0", "-p", "0", "-w"]
 powersave_mode = ["-m", "powersave", "-d", "-p", "5000"]
-server_mode = ["-a", "-s", "20000"]
+server_mode = ["-s", "20000"]
 
 [scheds.scx_beerland]
 auto_mode = []


### PR DESCRIPTION
Removed the -a option from the server profile, as it was too aggressive in packing threads onto the same CPU.
This behavior could lead to severe load imbalance, overloading some CPUs while leaving others idle.