### PR TITLE
scx_loader: use systemd polkit auth integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "zbus",
+ "zbus_polkit",
  "zvariant",
 ]
 
@@ -1443,6 +1444,19 @@ dependencies = [
  "static_assertions",
  "winnow",
  "zvariant",
+]
+
+[[package]]
+name = "zbus_polkit"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad23d5c4d198c7e2641b33e6e0d1f866f117408ba66fe80bbe52e289eeb77c52"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "serde_repr",
+ "static_assertions",
+ "zbus",
 ]
 
 [[package]]

--- a/configs/org.scx.Loader.conf
+++ b/configs/org.scx.Loader.conf
@@ -2,14 +2,60 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-<!-- why do we allow receive_sender here?? -->
+
     <policy user="root">
         <allow own="org.scx.Loader"/>
+
         <allow send_destination="org.scx.Loader"/>
         <allow receive_sender="org.scx.Loader"/>
     </policy>
+
     <policy context="default">
-        <allow send_destination="org.scx.Loader"/>
+        <deny send_destination="org.scx.Loader"/>
+
+        <!-- Completely open to anyone: org.freedesktop.DBus.* interfaces -->
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.freedesktop.DBus.Introspectable"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.freedesktop.DBus.Peer"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.freedesktop.DBus.Properties"
+               send_member="Get"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.freedesktop.DBus.Properties"
+               send_member="GetAll"/>
+
+        <!-- Managed via polkit: org.scx.loader.manage-schedulers action id -->
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="StartScheduler"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="StartSchedulerWithArgs"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="SwitchScheduler"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="SwitchSchedulerWithArgs"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="StopScheduler"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="RestartScheduler"/>
+
         <allow receive_sender="org.scx.Loader"/>
     </policy>
+
 </busconfig>

--- a/configs/org.scx.Loader.policy
+++ b/configs/org.scx.Loader.policy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+
+<policyconfig>
+
+  <vendor>ScxLoader</vendor>
+  <vendor_url>https://github.com/sched-ext/scx-loader</vendor_url>
+
+  <action id="org.scx.loader.manage-schedulers">
+    <description>Manage sched-ext schedulers</description>
+    <message>Authentication is required to start, stop, or switch sched-ext schedulers.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
+</policyconfig>

--- a/crates/scx_loader/Cargo.toml
+++ b/crates/scx_loader/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.42.0", features = ["macros", "sync", "rt-multi-thread", "
 tokio-util = "0.7.13"
 toml = "0.8.19"
 zbus = { version = "5.3.1", features = ["tokio"], default-features = false }
+zbus_polkit = { version = "5.0.0", features = ["tokio"], default-features = false }
 zvariant = "5.1"
 
 [lib]
@@ -31,6 +32,7 @@ path = "src/main.rs"
 [package.metadata.install-files]
 # [verbose name] -> { target = "src location", dest = "destination with annotated env vars" }
 dbus-policy = { target = "configs/org.scx.Loader.conf", dest = "$datadir/dbus-1/system.d/org.scx.Loader.conf" }
+polkit-policy = { target = "configs/org.scx.Loader.policy", dest = "$datadir/polkit-1/actions/org.scx.Loader.policy" }
 example-config = { target = "configs/scx_loader.toml", dest = "$datadir/scx_loader/config.toml" }
 dbus-service = { target = "services/org.scx.Loader.service", dest = "$datadir/dbus-1/system-services/org.scx.Loader.service" }
 systemd-service = { target = "services/scx_loader.service", dest = "$libdir/systemd/system/scx_loader.service" }

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -28,7 +28,9 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::Duration;
 use tokio::time::Instant;
 use zbus::interface;
+use zbus::message::Header;
 use zbus::Connection;
+use zbus_polkit::policykit1::{AuthorityProxy, CheckAuthorizationFlags, Subject};
 
 #[derive(Debug, PartialEq)]
 enum ScxMessage {
@@ -74,6 +76,8 @@ struct Args {
     auto: bool,
 }
 
+const ROOT_ACTION_ID: &str = "org.scx.loader.manage-schedulers";
+
 #[interface(name = "org.scx.Loader")]
 impl ScxLoader {
     /// Get currently running scheduler, in case non is running return "unknown"
@@ -82,9 +86,10 @@ impl ScxLoader {
         if let Some(current_scx) = &self.current_scx {
             let current_scx: &str = current_scx.clone().into();
             log::info!("called {current_scx:?}");
-            return current_scx.to_owned();
+            current_scx.into()
+        } else {
+            "unknown".into()
         }
-        "unknown".to_owned()
     }
 
     /// Get scheduler mode
@@ -114,7 +119,15 @@ impl ScxLoader {
             "scx_rusty",
         ]
     }
-    fn start_scheduler(&mut self, scx_name: SupportedSched, sched_mode: SchedMode) {
+
+    async fn start_scheduler(
+        &mut self,
+        #[zbus(connection)] conn: &Connection,
+        #[zbus(header)] hdr: Header<'_>,
+        scx_name: SupportedSched,
+        sched_mode: SchedMode,
+    ) -> zbus::fdo::Result<()> {
+        check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
         log::info!("starting {scx_name:?} with mode {sched_mode:?}..");
 
         let _ = self
@@ -123,9 +136,18 @@ impl ScxLoader {
         self.current_scx = Some(scx_name);
         self.current_mode = sched_mode;
         self.current_args = None;
+
+        Ok(())
     }
 
-    fn start_scheduler_with_args(&mut self, scx_name: SupportedSched, scx_args: Vec<String>) {
+    async fn start_scheduler_with_args(
+        &mut self,
+        #[zbus(connection)] conn: &Connection,
+        #[zbus(header)] hdr: Header<'_>,
+        scx_name: SupportedSched,
+        scx_args: Vec<String>,
+    ) -> zbus::fdo::Result<()> {
+        check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
         log::info!("starting {scx_name:?} with args {scx_args:?}..");
 
         let _ = self.channel.send(ScxMessage::StartSchedArgs((
@@ -136,9 +158,18 @@ impl ScxLoader {
         // reset mode to auto
         self.current_mode = SchedMode::Auto;
         self.current_args = Some(scx_args);
+
+        Ok(())
     }
 
-    fn switch_scheduler(&mut self, scx_name: SupportedSched, sched_mode: SchedMode) {
+    async fn switch_scheduler(
+        &mut self,
+        #[zbus(connection)] conn: &Connection,
+        #[zbus(header)] hdr: Header<'_>,
+        scx_name: SupportedSched,
+        sched_mode: SchedMode,
+    ) -> zbus::fdo::Result<()> {
+        check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
         log::info!("switching {scx_name:?} with mode {sched_mode:?}..");
 
         let _ = self
@@ -147,9 +178,18 @@ impl ScxLoader {
         self.current_scx = Some(scx_name);
         self.current_mode = sched_mode;
         self.current_args = None;
+
+        Ok(())
     }
 
-    fn switch_scheduler_with_args(&mut self, scx_name: SupportedSched, scx_args: Vec<String>) {
+    async fn switch_scheduler_with_args(
+        &mut self,
+        #[zbus(connection)] conn: &Connection,
+        #[zbus(header)] hdr: Header<'_>,
+        scx_name: SupportedSched,
+        scx_args: Vec<String>,
+    ) -> zbus::fdo::Result<()> {
+        check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
         log::info!("switching {scx_name:?} with args {scx_args:?}..");
 
         let _ = self.channel.send(ScxMessage::SwitchSchedArgs((
@@ -160,9 +200,16 @@ impl ScxLoader {
         // reset mode to auto
         self.current_mode = SchedMode::Auto;
         self.current_args = Some(scx_args);
+
+        Ok(())
     }
 
-    fn stop_scheduler(&mut self) {
+    async fn stop_scheduler(
+        &mut self,
+        #[zbus(connection)] conn: &Connection,
+        #[zbus(header)] hdr: Header<'_>,
+    ) -> zbus::fdo::Result<()> {
+        check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
         if let Some(current_scx) = &self.current_scx {
             let scx_name: &str = current_scx.clone().into();
 
@@ -171,9 +218,16 @@ impl ScxLoader {
             self.current_scx = None;
             self.current_args = None;
         }
+
+        Ok(())
     }
 
-    fn restart_scheduler(&mut self) -> zbus::fdo::Result<()> {
+    async fn restart_scheduler(
+        &mut self,
+        #[zbus(connection)] conn: &Connection,
+        #[zbus(header)] hdr: Header<'_>,
+    ) -> zbus::fdo::Result<()> {
+        check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
         if let Some(current_scx) = &self.current_scx {
             let scx_name: &str = current_scx.clone().into();
 
@@ -558,4 +612,42 @@ async fn stop_scheduler(
         // Create a new cancellation token
         *cancel_token = Arc::new(tokio_util::sync::CancellationToken::new());
     }
+}
+
+async fn check_authorization(
+    connection: &Connection,
+    header: &Header<'_>,
+    action_id: &str,
+) -> anyhow::Result<()> {
+    log::debug!("Checking auth");
+    let proxy = AuthorityProxy::new(connection).await?;
+
+    let subject = Subject::new_for_message_header(header).expect("Failed to create polkit subject");
+    let auth_result = proxy
+        .check_authorization(
+            &subject,
+            action_id,
+            &std::collections::HashMap::new(),
+            CheckAuthorizationFlags::AllowUserInteraction.into(),
+            "",
+        )
+        .await?;
+    if !auth_result.is_authorized {
+        anyhow::bail!("Not allowed!");
+    }
+    log::debug!("Auth allowed");
+
+    Ok(())
+}
+
+async fn check_authorization_inter(
+    connection: &Connection,
+    header: &Header<'_>,
+    action_id: &str,
+) -> zbus::fdo::Result<()> {
+    if let Err(auth_err) = check_authorization(connection, header, action_id).await {
+        return Err(zbus::fdo::Error::Failed(auth_err.to_string()));
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Reuse existing feature of systemd polkit auth to restrict DBUS interface methods.

DBUS config policy makes use of similar schema as org.freedesktop.systemd1

Fixes #12