### PR TITLE
scx_loader: fix scx_tickless powersave mode

### DIFF
--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -60,7 +60,7 @@ server_mode = ["--keep-running"]
 auto_mode = []
 gaming_mode = ["-f", "5000", "-s", "5000"]
 lowlatency_mode = ["-f", "5000", "-s", "1000"]
-powersave_mode = ["-f", "50", "-p"]
+powersave_mode = ["-f", "50"]
 server_mode = ["-f", "100"]
 
 [scheds.scx_rustland]
@@ -129,7 +129,7 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_tickless`:
     * Gaming mode: `-f 5000 -s 5000`
     * Low Latency mode: `-f 5000 -s 1000`
-    * Power Save mode: `-f 50 -p`
+    * Power Save mode: `-f 50`
     * Server mode: `-f 100`
 * For `scx_p2dq`:
     * Gaming mode: `--task-slice true -f --sched-mode performance`

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -242,7 +242,7 @@ fn get_default_scx_flags_for_mode(
         SupportedSched::Tickless => match sched_mode {
             SchedMode::Gaming => vec!["-f", "5000", "-s", "5000"],
             SchedMode::LowLatency => vec!["-f", "5000", "-s", "1000"],
-            SchedMode::PowerSave => vec!["-f", "50", "-p"],
+            SchedMode::PowerSave => vec!["-f", "50"],
             SchedMode::Server => vec!["-f", "100"],
             SchedMode::Auto => vec![],
         },
@@ -315,7 +315,7 @@ server_mode = ["--keep-running"]
 auto_mode = []
 gaming_mode = ["-f", "5000", "-s", "5000"]
 lowlatency_mode = ["-f", "5000", "-s", "1000"]
-powersave_mode = ["-f", "50", "-p"]
+powersave_mode = ["-f", "50"]
 server_mode = ["-f", "100"]
 
 [scheds.scx_rustland]


### PR DESCRIPTION
The `-p` parameter does not exist, which causes the entire `powersave mode` to be buggy. 

```
lis 12 11:40:56 cachyos-x8664 systemd[1]: Starting DBUS on-demand loader of sched-ext schedulers...
lis 12 11:40:56 cachyos-x8664 scx_loader[448]: [INFO]: Starting as dbus interface
lis 12 11:40:56 cachyos-x8664 systemd[1]: Started DBUS on-demand loader of sched-ext schedulers.
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [INFO]: starting Tickless with mode PowerSave..
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [INFO]: Got event to start scheduler!
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [INFO]: starting scx_tickless command
lis 12 14:40:15 cachyos-x8664 scx_loader[5164]: error: unexpected argument '-p' found
lis 12 14:40:15 cachyos-x8664 scx_loader[5164]: Usage: scx_tickless [OPTIONS]
lis 12 14:40:15 cachyos-x8664 scx_loader[5164]: For more information, try '--help'.
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [ERROR]: Failed to start scheduler (attempt 1/5)
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [INFO]: starting scx_tickless command
lis 12 14:40:15 cachyos-x8664 scx_loader[5170]: error: unexpected argument '-p' found
lis 12 14:40:15 cachyos-x8664 scx_loader[5170]: Usage: scx_tickless [OPTIONS]
lis 12 14:40:15 cachyos-x8664 scx_loader[5170]: For more information, try '--help'.
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [ERROR]: Failed to start scheduler (attempt 2/5)
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [INFO]: starting scx_tickless command
lis 12 14:40:15 cachyos-x8664 scx_loader[5172]: error: unexpected argument '-p' found
lis 12 14:40:15 cachyos-x8664 scx_loader[5172]: Usage: scx_tickless [OPTIONS]
lis 12 14:40:15 cachyos-x8664 scx_loader[5172]: For more information, try '--help'.
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [ERROR]: Failed to start scheduler (attempt 3/5)
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [INFO]: starting scx_tickless command
lis 12 14:40:15 cachyos-x8664 scx_loader[5173]: error: unexpected argument '-p' found
lis 12 14:40:15 cachyos-x8664 scx_loader[5173]: Usage: scx_tickless [OPTIONS]
lis 12 14:40:15 cachyos-x8664 scx_loader[5173]: For more information, try '--help'.
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [ERROR]: Failed to start scheduler (attempt 4/5)
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [INFO]: starting scx_tickless command
lis 12 14:40:15 cachyos-x8664 scx_loader[5175]: error: unexpected argument '-p' found
lis 12 14:40:15 cachyos-x8664 scx_loader[5175]: Usage: scx_tickless [OPTIONS]
lis 12 14:40:15 cachyos-x8664 scx_loader[5175]: For more information, try '--help'.
lis 12 14:40:15 cachyos-x8664 scx_loader[448]: [ERROR]: Failed to start scheduler (attempt 5/5)

```