### PR TITLE
ci: remove paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,7 @@ name: Cargo Build & Test
 
 on:
   push:
-    paths-ignore:
-      - 'LICENSE'
-      - '*.md'
-      - '*.sh'
   pull_request:
-    paths-ignore:
-      - 'LICENSE'
-      - '*.md'
-      - '*.sh'
 
 permissions:
   contents: read


### PR DESCRIPTION
These checks are required on pull requests so they must always run. If you want to make the check simpler for this type of PR in future you need to skip a job, not the whole thing, and then that needs to take account of the required_checks on GitHub too.

Test plan:
- CI