### PR TITLE
chore: add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.gitignore
+PKGBUILD
+target
+*.swp
+.cache/
+.vscode/
+tags
+selftest
+CLAUDE.md


### PR DESCRIPTION
Repo lost its .gitignore after being split from the main scx repo. This is a copy of the one from the main scx repo, with the c and bpf specific ignores removed.