### PR TITLE
scx_loader: Lockdown systemd service

### DIFF
--- a/services/scx_loader.service
+++ b/services/scx_loader.service
@@ -6,6 +6,26 @@ Type=dbus
 BusName=org.scx.Loader
 ExecStart=/usr/bin/scx_loader
 KillSignal=SIGINT
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=disconnected
+PrivateDevices=true
+PrivateMounts=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+LockPersonality=true
+RestrictRealtime=true
+ProtectClock=true
+MemoryDenyWriteExecute=true
+RestrictAddressFamilies=AF_UNIX
+SocketBindDeny=ipv4:tcp
+SocketBindDeny=ipv4:udp
+SocketBindDeny=ipv6:tcp
+SocketBindDeny=ipv6:udp
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_CHOWN CAP_IPC_LOCK CAP_MKNOD CAP_NET_RAW CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYS_MODULE CAP_SYS_PACCT CAP_SYS_PTRACE CAP_SYS_TIME CAP_SYSLOG CAP_WAKE_ALARM
+SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @obsolete:EPERM @pkey:EPERM @raw-io:EPERM @reboot:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM
 
 [Install]
 WantedBy=multi-user.target

--- a/services/scx_loader.service
+++ b/services/scx_loader.service
@@ -7,11 +7,8 @@ BusName=org.scx.Loader
 ExecStart=/usr/bin/scx_loader
 KillSignal=SIGINT
 ProtectSystem=full
-ProtectHome=true
 PrivateTmp=disconnected
-PrivateDevices=true
 PrivateMounts=true
-ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true
@@ -24,8 +21,8 @@ SocketBindDeny=ipv4:tcp
 SocketBindDeny=ipv4:udp
 SocketBindDeny=ipv6:tcp
 SocketBindDeny=ipv6:udp
-CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_CHOWN CAP_IPC_LOCK CAP_MKNOD CAP_NET_RAW CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYS_MODULE CAP_SYS_PACCT CAP_SYS_PTRACE CAP_SYS_TIME CAP_SYSLOG CAP_WAKE_ALARM
-SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @obsolete:EPERM @pkey:EPERM @raw-io:EPERM @reboot:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_CHOWN CAP_MKNOD CAP_NET_RAW CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYS_MODULE CAP_SYS_PACCT CAP_SYS_PTRACE CAP_SYS_TIME CAP_SYSLOG CAP_WAKE_ALARM
+SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @keyring:EPERM @module:EPERM @mount:EPERM @obsolete:EPERM @pkey:EPERM @raw-io:EPERM @reboot:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is an attempt to perform the systemd hardening suggested by #12 . The following options were determined by profiling the service with [shh (systemd hardening helper)](https://github.com/desbma/shh). It was done by starting profiling with shh, running through every scxctl option (stop, start sched with modes/args, switch with modes/args, restart, get, list), then ending profiling. AFAICT everything works fine w/ the new hardening options, but I would appreciate testing to make sure it works on more than just my system. 