### PR TITLE
build: Reduce the binary size for the release-tiny profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ inherits = "release"
 lto = "thin"
 strip = true
 incremental = true
+codegen-units = 1
 
 [profile.release-fast]
 inherits = "release"


### PR DESCRIPTION
The pull request https://github.com/sched-ext/scx/pull/3138 allowed us to reduce the size of binaries in scx-scheds. Let's introduce similar functionality in scx-loader and scxctl.