### PR TITLE
scx_loader: update cosmos auto mode

### DIFF
--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -71,7 +71,7 @@ powersave_mode = []
 server_mode = []
 
 [scheds.scx_cosmos]
-auto_mode = ["-d"]
+auto_mode = ["-s", "20000", "-d", "-c", "0", "-p", "0"]
 gaming_mode = ["-c", "0", "-p", "0"]
 lowlatency_mode = ["-m", "performance", "-c", "0", "-p", "0", "-w"]
 powersave_mode = ["-m", "powersave", "-d", "-p", "5000"]

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -251,7 +251,7 @@ fn get_default_scx_flags_for_mode(
             SchedMode::LowLatency => vec!["-m", "performance", "-c", "0", "-p", "0", "-w"],
             SchedMode::PowerSave => vec!["-m", "powersave", "-d", "-p", "5000"],
             SchedMode::Server => vec!["-s", "20000"],
-            SchedMode::Auto => vec!["-d"],
+            SchedMode::Auto => vec!["-s", "20000", "-d", "-c", "0", "-p", "0"],
         },
         // scx_rusty, scx_rustland, scx_beerland doesn't support any of these modes
         SupportedSched::Rusty | SupportedSched::Rustland | SupportedSched::Beerland => vec![],
@@ -326,7 +326,7 @@ powersave_mode = []
 server_mode = []
 
 [scheds.scx_cosmos]
-auto_mode = ["-d"]
+auto_mode = ["-s", "20000", "-d", "-c", "0", "-p", "0"]
 gaming_mode = ["-c", "0", "-p", "0"]
 lowlatency_mode = ["-m", "performance", "-c", "0", "-p", "0", "-w"]
 powersave_mode = ["-m", "powersave", "-d", "-p", "5000"]


### PR DESCRIPTION
In the next release, the auto flag in scx_cosmos should contain new values: https://github.com/sched-ext/scx/pull/3226/commits/2f747c868a312e09288f0d4ea45432818f7e1101