### PR TITLE
Revert "scx_loader: Add timely scheduler (#46)"

### DIFF
--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -97,13 +97,6 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
-
-[scheds.scx_timely]
-auto_mode = ["--mode", "desktop"]
-gaming_mode = ["--mode", "desktop"]
-lowlatency_mode = ["--mode", "desktop"]
-powersave_mode = ["--mode", "powersave"]
-server_mode = ["--mode", "server"]
 ```
 
 **`default_sched`:**
@@ -173,11 +166,6 @@ The example configuration above shows how to set custom flags for different sche
     * Server mode: `--profile gaming`
 * For `scx_pandemonium`:
     * No custom flags are defined, so the default flags for each mode will be used.
-* For `scx_timely`:
-    * Gaming mode: `--mode desktop`
-    * Low Latency mode: `--mode desktop`
-    * Power Save mode: `--mode powersave`
-    * Server mode: `--mode server`
 
 ### Fallback Behavior
 

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -108,7 +108,6 @@ pub fn get_default_config() -> Config {
         SupportedSched::Beerland,
         SupportedSched::Cake,
         SupportedSched::Pandemonium,
-        SupportedSched::Timely,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(init_default_config_entry));
     Config {
@@ -262,13 +261,6 @@ fn get_default_scx_flags_for_mode(
             SchedMode::PowerSave => vec!["--profile", "battery"],
             SchedMode::Auto => vec!["--profile", "default"],
         },
-        SupportedSched::Timely => match sched_mode {
-            SchedMode::Gaming | SchedMode::LowLatency | SchedMode::Auto => {
-                vec!["--mode", "desktop"]
-            }
-            SchedMode::PowerSave => vec!["--mode", "powersave"],
-            SchedMode::Server => vec!["--mode", "server"],
-        },
         // The below Schedulers haven't defined any modes
         SupportedSched::Rusty
         | SupportedSched::Rustland
@@ -371,13 +363,6 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
-
-[scheds.scx_timely]
-auto_mode = ["--mode", "desktop"]
-gaming_mode = ["--mode", "desktop"]
-lowlatency_mode = ["--mode", "desktop"]
-powersave_mode = ["--mode", "powersave"]
-server_mode = ["--mode", "server"]
 "#;
 
         let parsed_config = parse_config_content(config_str).expect("Failed to parse config");

--- a/crates/scx_loader/src/lib.rs
+++ b/crates/scx_loader/src/lib.rs
@@ -42,8 +42,6 @@ pub enum SupportedSched {
     Cake,
     #[serde(rename = "scx_pandemonium")]
     Pandemonium,
-    #[serde(rename = "scx_timely")]
-    Timely,
 }
 
 impl FromStr for SupportedSched {
@@ -62,7 +60,6 @@ impl FromStr for SupportedSched {
             "scx_tickless" => Ok(SupportedSched::Tickless),
             "scx_rustland" => Ok(SupportedSched::Rustland),
             "scx_rusty" => Ok(SupportedSched::Rusty),
-            "scx_timely" => Ok(SupportedSched::Timely),
             _ => Err(anyhow::anyhow!("{scx_name} is not supported")),
         }
     }
@@ -89,7 +86,6 @@ impl From<SupportedSched> for &str {
             SupportedSched::Tickless => "scx_tickless",
             SupportedSched::Rustland => "scx_rustland",
             SupportedSched::Rusty => "scx_rusty",
-            SupportedSched::Timely => "scx_timely",
         }
     }
 }

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -122,7 +122,6 @@ impl ScxLoader {
             "scx_tickless",
             "scx_rustland",
             "scx_rusty",
-            "scx_timely",
         ]
     }
 


### PR DESCRIPTION
This reverts commit 80342f21ab827f42d5bb9e0010aa2ddf9e03d659.

Following a discussion at https://github.com/sched-ext/scx/pull/3463 we decided that scx_timely would be merged into scx_bpfland.