### PR TITLE
scx_loader: Add flow scheduler

### DIFF
--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -97,6 +97,13 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
+
+[scheds.scx_flow]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 ```
 
 **`default_sched`:**
@@ -162,6 +169,8 @@ The example configuration above shows how to set custom flags for different sche
     * Power Save mode: `--profile battery`
     * Server mode: `--profile gaming`
 * For `scx_pandemonium`:
+    * No custom flags are defined, so the default flags for each mode will be used.
+* For `scx_flow`:
     * No custom flags are defined, so the default flags for each mode will be used.
 
 ### Fallback Behavior

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -108,6 +108,7 @@ pub fn get_default_config() -> Config {
         SupportedSched::Beerland,
         SupportedSched::Cake,
         SupportedSched::Pandemonium,
+        SupportedSched::Flow,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(init_default_config_entry));
     Config {
@@ -246,7 +247,8 @@ fn get_default_scx_flags_for_mode(
         | SupportedSched::Rustland
         | SupportedSched::Beerland
         | SupportedSched::Pandemonium
-        | SupportedSched::Flash => vec![],
+        | SupportedSched::Flash
+        | SupportedSched::Flow => vec![],
     }
 }
 
@@ -339,6 +341,13 @@ powersave_mode = ["--profile", "battery"]
 server_mode = ["--profile", "gaming"]
 
 [scheds.scx_pandemonium]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
+
+[scheds.scx_flow]
 auto_mode = []
 gaming_mode = []
 lowlatency_mode = []

--- a/crates/scx_loader/src/lib.rs
+++ b/crates/scx_loader/src/lib.rs
@@ -42,6 +42,8 @@ pub enum SupportedSched {
     Cake,
     #[serde(rename = "scx_pandemonium")]
     Pandemonium,
+    #[serde(rename = "scx_flow")]
+    Flow,
 }
 
 impl FromStr for SupportedSched {
@@ -54,6 +56,7 @@ impl FromStr for SupportedSched {
             "scx_cake" => Ok(SupportedSched::Cake),
             "scx_cosmos" => Ok(SupportedSched::Cosmos),
             "scx_flash" => Ok(SupportedSched::Flash),
+            "scx_flow" => Ok(SupportedSched::Flow),
             "scx_lavd" => Ok(SupportedSched::Lavd),
             "scx_pandemonium" => Ok(SupportedSched::Pandemonium),
             "scx_p2dq" => Ok(SupportedSched::P2DQ),
@@ -80,6 +83,7 @@ impl From<SupportedSched> for &str {
             SupportedSched::Cake => "scx_cake",
             SupportedSched::Cosmos => "scx_cosmos",
             SupportedSched::Flash => "scx_flash",
+            SupportedSched::Flow => "scx_flow",
             SupportedSched::Lavd => "scx_lavd",
             SupportedSched::Pandemonium => "scx_pandemonium",
             SupportedSched::P2DQ => "scx_p2dq",

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -116,6 +116,7 @@ impl ScxLoader {
             "scx_cake",
             "scx_cosmos",
             "scx_flash",
+            "scx_flow",
             "scx_lavd",
             "scx_pandemonium",
             "scx_p2dq",


### PR DESCRIPTION
Add scx_flow to scx_loader.

```
lucjan at cachyos ~ 8:25:51    
❯ scxctl start -s flow                                                      
started Flow in Auto mode
lucjan at cachyos ~ 8:25:59    
❯ systemctl status scx_loader.service
● scx_loader.service - DBUS on-demand loader of sched-ext schedulers
     Loaded: loaded (/usr/lib/systemd/system/scx_loader.service; disabled; preset: disabled)
     Active: active (running) since Fri 2026-04-17 08:25:55 CEST; 6s ago
 Invocation: 6994cec330a14634ac764b3738bfdcb9
   Main PID: 45264 (scx_loader)
      Tasks: 23 (limit: 37546)
     Memory: 15.1M (peak: 24.4M)
        CPU: 290ms
     CGroup: /system.slice/scx_loader.service
             ├─45264 /usr/bin/scx_loader
             └─45314 scx_flow

kwi 17 08:25:55 cachyos systemd[1]: Starting DBUS on-demand loader of sched-ext schedulers...
kwi 17 08:25:55 cachyos scx_loader[45264]: [INFO]: Starting as dbus interface
kwi 17 08:25:55 cachyos systemd[1]: Started DBUS on-demand loader of sched-ext schedulers.
kwi 17 08:25:59 cachyos scx_loader[45264]: [INFO]: starting Flow with mode Auto..
kwi 17 08:25:59 cachyos scx_loader[45264]: [INFO]: Got event to start scheduler!
kwi 17 08:25:59 cachyos scx_loader[45264]: [INFO]: starting scx_flow command
kwi 17 08:25:59 cachyos scx_loader[45314]: 06:25:59 [INFO] scx_flow 2.2.0 x86_64-unknown-linux-gnu
kwi 17 08:25:59 cachyos scx_loader[45314]: 06:25:59 [INFO] Starting scx_flow scheduler
```