### PR TITLE
dbus: add hold/release cookie mechanism for scheduler state management

### DIFF
--- a/configs/org.scx.Loader.conf
+++ b/configs/org.scx.Loader.conf
@@ -59,6 +59,14 @@
                send_interface="org.scx.Loader"
                send_member="RestoreDefault"/>
 
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="HoldScheduler"/>
+
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="ReleaseScheduler"/>
+
         <allow receive_sender="org.scx.Loader"/>
     </policy>
 

--- a/configs/org.scx.Loader.xml
+++ b/configs/org.scx.Loader.xml
@@ -66,6 +66,15 @@
     <property name="DefaultMode" type="u" access="read"/>
 
     <!--
+        ActiveHolds:
+
+        Currently active scheduler holds, ordered oldest-first.
+        Each entry is a struct with fields:
+        (cookie: u, scheduler: s, mode: u, reason: s, app_id: s).
+    -->
+    <property name="ActiveHolds" type="a(ususs)" access="read"/>
+
+    <!--
         StartScheduler:
 
         Starts the specified scheduler with the given mode.
@@ -137,7 +146,7 @@
         RestartScheduler:
 
         Restarts the currently running scheduler with its original configuration.
-        This method will stop the currently running scheduler and then restart 
+        This method will stop the currently running scheduler and then restart
         it with the same scheduler and arguments/mode that were used originally.
         Returns an error if no scheduler is currently running.
     -->
@@ -154,5 +163,43 @@
     -->
     <method name="RestoreDefault">
     </method>
+
+    <!--
+        HoldScheduler:
+
+        Activates the requested scheduler/mode for the lifetime of the hold.
+        The pre-hold scheduler state is saved and restored when every hold
+        has been released.  Multiple concurrent holds are supported; the most
+        recently acquired hold wins (last-write-wins).
+
+        @scheduler: The name of the scheduler to hold (e.g., "scx_lavd").
+        @mode: The scheduler mode (profile) as an unsigned integer.
+               See the SchedulerMode property for details.
+        @reason: A human-readable reason string (shown in ActiveHolds).
+        @app_id: A reverse-DNS application identifier (e.g., "org.gnome.Games").
+        @cookie: An opaque handle that must be passed to ReleaseScheduler.
+    -->
+    <method name="HoldScheduler">
+      <arg name="scheduler" type="s" direction="in"/>
+      <arg name="mode" type="u" direction="in"/>
+      <arg name="reason" type="s" direction="in"/>
+      <arg name="app_id" type="s" direction="in"/>
+      <arg name="cookie" type="u" direction="out"/>
+    </method>
+
+    <!--
+        ReleaseScheduler:
+
+        Releases the hold identified by the cookie.
+        When the last hold is released the scheduler state that was active
+        before the first hold is restored.  If other holds remain, the most
+        recently acquired one becomes active.
+
+        @cookie: The value previously returned by HoldScheduler.
+    -->
+    <method name="ReleaseScheduler">
+      <arg name="cookie" type="u" direction="in"/>
+    </method>
+
   </interface>
 </node>

--- a/crates/scx_loader/src/dbus.rs
+++ b/crates/scx_loader/src/dbus.rs
@@ -5,6 +5,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
+use crate::HoldEntry;
 use crate::SchedMode;
 use crate::SupportedSched;
 
@@ -53,6 +54,25 @@ pub trait LoaderClient {
     /// Returns an error if no default scheduler is configured.
     fn restore_default(&self) -> zbus::Result<()>;
 
+    /// Activates the requested scheduler/mode for the duration of the hold.
+    /// Returns an opaque cookie that must be passed to `ReleaseScheduler`.
+    /// If multiple holds are active the most recently acquired hold wins.
+    /// The pre-hold scheduler state is saved and restored when all holds are
+    /// released.
+    fn hold_scheduler(
+        &self,
+        scheduler: &str,
+        mode: u32,
+        reason: &str,
+        app_id: &str,
+    ) -> zbus::Result<u32>;
+
+    /// Releases the hold identified by `cookie`.
+    /// When the last hold is released the scheduler state that was active
+    /// before the first hold is restored.  If other holds remain, the most
+    /// recently acquired one becomes active.
+    fn release_scheduler(&self, cookie: u32) -> zbus::Result<()>;
+
     /// The name of the currently running scheduler. If no scheduler is active,
     /// this property will be set to "unknown".
     #[zbus(property)]
@@ -87,4 +107,10 @@ pub trait LoaderClient {
     /// Defaults to 0 (Auto) if not explicitly configured.
     #[zbus(property)]
     fn default_mode(&self) -> zbus::Result<SchedMode>;
+
+    /// Currently active holds, ordered oldest-first.
+    /// Each entry is a struct `(cookie: u32, scheduler: s, mode: u32,
+    /// reason: s, app_id: s)`.
+    #[zbus(property)]
+    fn active_holds(&self) -> zbus::Result<Vec<HoldEntry>>;
 }

--- a/crates/scx_loader/src/dbus.rs
+++ b/crates/scx_loader/src/dbus.rs
@@ -61,8 +61,8 @@ pub trait LoaderClient {
     /// released.
     fn hold_scheduler(
         &self,
-        scheduler: &str,
-        mode: u32,
+        scheduler: SupportedSched,
+        mode: SchedMode,
         reason: &str,
         app_id: &str,
     ) -> zbus::Result<u32>;

--- a/crates/scx_loader/src/lib.rs
+++ b/crates/scx_loader/src/lib.rs
@@ -167,7 +167,7 @@ pub struct SchedState {
 }
 
 /// A single active hold entry, exposed via the `ActiveHolds` property
-/// (array of structs: `a(usssu)`).
+/// (array of structs: `a(ususs)`).
 #[derive(Debug, Clone, Type, Value, OwnedValue, Serialize, Deserialize)]
 pub struct HoldEntry {
     /// Opaque cookie returned to the caller.

--- a/crates/scx_loader/src/lib.rs
+++ b/crates/scx_loader/src/lib.rs
@@ -141,3 +141,43 @@ impl From<SchedMode> for &str {
         }
     }
 }
+
+impl TryFrom<u32> for SchedMode {
+    type Error = anyhow::Error;
+
+    fn try_from(v: u32) -> Result<Self, Self::Error> {
+        match v {
+            0 => Ok(SchedMode::Auto),
+            1 => Ok(SchedMode::Gaming),
+            2 => Ok(SchedMode::PowerSave),
+            3 => Ok(SchedMode::LowLatency),
+            4 => Ok(SchedMode::Server),
+            _ => Err(anyhow::anyhow!("unknown SchedMode value {v}")),
+        }
+    }
+}
+
+/// Snapshot of scheduler state saved before the first hold is placed.
+/// `sched == None` means no scheduler was running at that point.
+#[derive(Debug, Clone)]
+pub struct SchedState {
+    pub sched: Option<SupportedSched>,
+    pub mode: SchedMode,
+    pub args: Option<Vec<String>>,
+}
+
+/// A single active hold entry, exposed via the `ActiveHolds` property
+/// (array of structs: `a(usssu)`).
+#[derive(Debug, Clone, Type, Value, OwnedValue, Serialize, Deserialize)]
+pub struct HoldEntry {
+    /// Opaque cookie returned to the caller.
+    pub cookie: u32,
+    /// Scheduler name requested by this hold.
+    pub scheduler: String,
+    /// Scheduler mode requested by this hold.
+    pub mode: u32,
+    /// Human-readable reason supplied by the caller.
+    pub reason: String,
+    /// Application identifier supplied by the caller.
+    pub app_id: String,
+}

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -384,18 +384,12 @@ impl ScxLoader {
         &mut self,
         #[zbus(connection)] conn: &Connection,
         #[zbus(header)] hdr: Header<'_>,
-        scheduler: String,
-        mode: u32,
+        scheduler: SupportedSched,
+        mode: SchedMode,
         reason: String,
         app_id: String,
     ) -> zbus::fdo::Result<u32> {
         check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
-
-        let sched = SupportedSched::try_from(scheduler.as_str()).map_err(|e| {
-            zbus::fdo::Error::Failed(format!("Unsupported scheduler '{scheduler}': {e}"))
-        })?;
-        let sched_mode = SchedMode::try_from(mode)
-            .map_err(|e| zbus::fdo::Error::Failed(format!("Unsupported mode '{mode}': {e}")))?;
 
         // Save pre-hold state on the very first hold
         if self.active_holds.is_empty() {
@@ -409,14 +403,14 @@ impl ScxLoader {
 
         let cookie = self.alloc_cookie();
         log::info!(
-            "hold_scheduler: cookie={cookie} sched={scheduler:?} mode={mode} \
+            "hold_scheduler: cookie={cookie} sched={scheduler:?} mode={mode:?} \
              reason={reason:?} app_id={app_id:?}"
         );
 
         self.active_holds.push(HoldEntry {
             cookie,
-            scheduler: scheduler.clone(),
-            mode,
+            scheduler: <SupportedSched as Into<&str>>::into(scheduler.clone()).to_owned(),
+            mode: mode as u32,
             reason,
             app_id,
         });
@@ -424,9 +418,9 @@ impl ScxLoader {
         // Last-write-wins: activate this hold immediately
         let _ = self
             .channel
-            .send(ScxMessage::SwitchSched((sched.clone(), sched_mode)));
-        self.current_scx = Some(sched);
-        self.current_mode = sched_mode;
+            .send(ScxMessage::SwitchSched((scheduler.clone(), mode)));
+        self.current_scx = Some(scheduler);
+        self.current_mode = mode;
         self.current_args = None;
 
         Ok(cookie)

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -197,6 +197,11 @@ impl ScxLoader {
         sched_mode: SchedMode,
     ) -> zbus::fdo::Result<()> {
         check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
+        if !self.active_holds.is_empty() {
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot start scheduler while holds are active".to_string(),
+            ));
+        }
         log::info!("starting {scx_name:?} with mode {sched_mode:?}..");
 
         let _ = self
@@ -217,6 +222,11 @@ impl ScxLoader {
         scx_args: Vec<String>,
     ) -> zbus::fdo::Result<()> {
         check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
+        if !self.active_holds.is_empty() {
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot start scheduler while holds are active".to_string(),
+            ));
+        }
         log::info!("starting {scx_name:?} with args {scx_args:?}..");
 
         let _ = self.channel.send(ScxMessage::StartSchedArgs((
@@ -239,6 +249,11 @@ impl ScxLoader {
         sched_mode: SchedMode,
     ) -> zbus::fdo::Result<()> {
         check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
+        if !self.active_holds.is_empty() {
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot switch scheduler while holds are active".to_string(),
+            ));
+        }
         log::info!("switching {scx_name:?} with mode {sched_mode:?}..");
 
         let _ = self
@@ -259,6 +274,11 @@ impl ScxLoader {
         scx_args: Vec<String>,
     ) -> zbus::fdo::Result<()> {
         check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
+        if !self.active_holds.is_empty() {
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot switch scheduler while holds are active".to_string(),
+            ));
+        }
         log::info!("switching {scx_name:?} with args {scx_args:?}..");
 
         let _ = self.channel.send(ScxMessage::SwitchSchedArgs((
@@ -279,6 +299,11 @@ impl ScxLoader {
         #[zbus(header)] hdr: Header<'_>,
     ) -> zbus::fdo::Result<()> {
         check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
+        if !self.active_holds.is_empty() {
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot stop scheduler while holds are active".to_string(),
+            ));
+        }
         if let Some(current_scx) = &self.current_scx {
             let scx_name: &str = current_scx.clone().into();
 
@@ -297,6 +322,11 @@ impl ScxLoader {
         #[zbus(header)] hdr: Header<'_>,
     ) -> zbus::fdo::Result<()> {
         check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
+        if !self.active_holds.is_empty() {
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot restart scheduler while holds are active".to_string(),
+            ));
+        }
         if let Some(current_scx) = &self.current_scx {
             let scx_name: &str = current_scx.clone().into();
 
@@ -322,7 +352,11 @@ impl ScxLoader {
         #[zbus(header)] hdr: Header<'_>,
     ) -> zbus::fdo::Result<()> {
         check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
-
+        if !self.active_holds.is_empty() {
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot restore default scheduler while holds are active".to_string(),
+            ));
+        }
         if let Some(default_scx) = &self.default_sched {
             let scx_name: &str = default_scx.clone().into();
             log::info!(

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -11,7 +11,7 @@
 mod logger;
 
 use scx_loader::dbus::LoaderClientProxy;
-use scx_loader::{config, SchedMode, SupportedSched};
+use scx_loader::{config, HoldEntry, SchedMode, SchedState, SupportedSched};
 
 use std::process::ExitStatus;
 use std::process::Stdio;
@@ -70,6 +70,46 @@ struct ScxLoader {
     // Store default configuration from config file
     default_sched: Option<SupportedSched>,
     default_mode: SchedMode,
+    // Hold state
+    next_cookie: u32,
+    active_holds: Vec<HoldEntry>,
+    pre_hold_state: Option<SchedState>,
+}
+
+impl ScxLoader {
+    fn snapshot_state(&self) -> SchedState {
+        SchedState {
+            sched: self.current_scx.clone(),
+            mode: self.current_mode,
+            args: self.current_args.clone(),
+        }
+    }
+
+    fn apply_state(&mut self, state: SchedState) {
+        if let Some(sched) = state.sched.clone() {
+            let msg = if let Some(args) = state.args.clone() {
+                self.current_args = Some(args.clone());
+                self.current_mode = SchedMode::Auto;
+                ScxMessage::SwitchSchedArgs((sched.clone(), args))
+            } else {
+                self.current_args = None;
+                self.current_mode = state.mode;
+                ScxMessage::SwitchSched((sched.clone(), state.mode))
+            };
+            self.current_scx = Some(sched);
+            let _ = self.channel.send(msg);
+        } else {
+            self.current_scx = None;
+            self.current_args = None;
+            let _ = self.channel.send(ScxMessage::StopSched);
+        }
+    }
+
+    fn alloc_cookie(&mut self) -> u32 {
+        let c = self.next_cookie;
+        self.next_cookie = self.next_cookie.wrapping_add(1);
+        c
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -141,6 +181,12 @@ impl ScxLoader {
     #[zbus(property)]
     fn default_mode(&self) -> SchedMode {
         self.default_mode
+    }
+
+    /// Get list of currently active holds
+    #[zbus(property)]
+    fn active_holds(&self) -> Vec<HoldEntry> {
+        self.active_holds.clone()
     }
 
     async fn start_scheduler(
@@ -299,6 +345,122 @@ impl ScxLoader {
             ))
         }
     }
+
+    async fn hold_scheduler(
+        &mut self,
+        #[zbus(connection)] conn: &Connection,
+        #[zbus(header)] hdr: Header<'_>,
+        scheduler: String,
+        mode: u32,
+        reason: String,
+        app_id: String,
+    ) -> zbus::fdo::Result<u32> {
+        check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
+
+        let sched = SupportedSched::try_from(scheduler.as_str()).map_err(|e| {
+            zbus::fdo::Error::Failed(format!("Unsupported scheduler '{scheduler}': {e}"))
+        })?;
+        let sched_mode = SchedMode::try_from(mode)
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Unsupported mode '{mode}': {e}")))?;
+
+        // Save pre-hold state on the very first hold
+        if self.active_holds.is_empty() {
+            self.pre_hold_state = Some(self.snapshot_state());
+            log::info!(
+                "hold_scheduler: saved pre-hold state ({:?}, {:?})",
+                self.pre_hold_state.as_ref().map(|s| &s.sched),
+                self.pre_hold_state.as_ref().map(|s| s.mode),
+            );
+        }
+
+        let cookie = self.alloc_cookie();
+        log::info!(
+            "hold_scheduler: cookie={cookie} sched={scheduler:?} mode={mode} \
+             reason={reason:?} app_id={app_id:?}"
+        );
+
+        self.active_holds.push(HoldEntry {
+            cookie,
+            scheduler: scheduler.clone(),
+            mode,
+            reason,
+            app_id,
+        });
+
+        // Last-write-wins: activate this hold immediately
+        let _ = self
+            .channel
+            .send(ScxMessage::SwitchSched((sched.clone(), sched_mode)));
+        self.current_scx = Some(sched);
+        self.current_mode = sched_mode;
+        self.current_args = None;
+
+        Ok(cookie)
+    }
+
+    async fn release_scheduler(
+        &mut self,
+        #[zbus(connection)] conn: &Connection,
+        #[zbus(header)] hdr: Header<'_>,
+        cookie: u32,
+    ) -> zbus::fdo::Result<()> {
+        check_authorization_inter(conn, &hdr, ROOT_ACTION_ID).await?;
+
+        let pos = self
+            .active_holds
+            .iter()
+            .position(|h| h.cookie == cookie)
+            .ok_or_else(|| {
+                zbus::fdo::Error::Failed(format!("No active hold with cookie {cookie}"))
+            })?;
+
+        self.active_holds.remove(pos);
+        log::info!("release_scheduler: released cookie={cookie}");
+
+        if self.active_holds.is_empty() {
+            // All holds gone — restore the pre-hold state
+            let state = self.pre_hold_state.take().unwrap_or(SchedState {
+                sched: None,
+                mode: SchedMode::Auto,
+                args: None,
+            });
+            log::info!(
+                "release_scheduler: all holds released, restoring pre-hold state \
+                 ({:?}, {:?})",
+                state.sched,
+                state.mode,
+            );
+            self.apply_state(state);
+        } else {
+            // Re-activate the most recently acquired remaining hold
+            let last = self.active_holds.last().unwrap().clone();
+            log::info!(
+                "release_scheduler: remaining holds, re-activating cookie={} sched={:?}",
+                last.cookie,
+                last.scheduler,
+            );
+            let sched = SupportedSched::try_from(last.scheduler.as_str()).map_err(|e| {
+                zbus::fdo::Error::Failed(format!(
+                    "Remaining hold has unsupported scheduler '{}': {e}",
+                    last.scheduler
+                ))
+            })?;
+            let sched_mode = SchedMode::try_from(last.mode).map_err(|e| {
+                zbus::fdo::Error::Failed(format!(
+                    "Remaining hold has unsupported mode '{}': {e}",
+                    last.mode
+                ))
+            })?;
+            let _ = self
+                .channel
+                .send(ScxMessage::SwitchSched((sched.clone(), sched_mode)));
+            self.current_scx = Some(sched);
+            self.current_mode = sched_mode;
+            self.current_args = None;
+        }
+
+        Ok(())
+    }
 }
 
 // Monitors CPU utilization and enables scx_lavd when utilization of any CPUs is > 90%
@@ -411,6 +573,9 @@ async fn main() -> Result<()> {
                 channel: channel.clone(),
                 default_sched: config.default_sched.clone(),
                 default_mode: config.default_mode.unwrap_or(SchedMode::Auto),
+                next_cookie: 0,
+                active_holds: Vec::new(),
+                pre_hold_state: None,
             },
         )
         .await?;

--- a/crates/scxctl/src/cli.rs
+++ b/crates/scxctl/src/cli.rs
@@ -57,6 +57,34 @@ pub struct SwitchArgs {
     pub args: Option<Vec<String>>,
 }
 
+#[derive(Parser, Debug)]
+pub struct HoldArgs {
+    #[arg(short, long, help = "Scheduler to hold", required = true)]
+    pub sched: String,
+    #[arg(
+        short,
+        long,
+        value_enum,
+        default_value = "auto",
+        help = "Mode to hold in"
+    )]
+    pub mode: SchedMode,
+    #[arg(
+        short,
+        long,
+        help = "Human-readable reason for the hold",
+        required = true
+    )]
+    pub reason: String,
+    #[arg(
+        short,
+        long,
+        help = "Reverse-DNS application identifier (e.g. org.gnome.Games)",
+        required = true
+    )]
+    pub app_id: String,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     #[command(about = "Get the info on the running scheduler")]
@@ -79,4 +107,16 @@ pub enum Commands {
     Restart,
     #[command(about = "Restore the default scheduler from configuration")]
     Restore,
+    #[command(about = "Place a scheduler hold and print the returned cookie")]
+    Hold {
+        #[clap(flatten)]
+        args: HoldArgs,
+    },
+    #[command(about = "Release a previously acquired scheduler hold by cookie")]
+    Release {
+        #[arg(help = "Cookie returned by the 'hold' command")]
+        cookie: u32,
+    },
+    #[command(about = "List all currently active scheduler holds")]
+    Holds,
 }

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -156,8 +156,7 @@ fn cmd_hold(
     app_id: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sched = validate_sched(scx_loader, sched_name);
-    let sched_str: &str = sched.clone().into();
-    let cookie = scx_loader.hold_scheduler(sched_str, mode as u32, &reason, &app_id)?;
+    let cookie = scx_loader.hold_scheduler(sched.clone(), mode, &reason, &app_id)?;
     println!(
         "holding {sched:?} in {mode:?} mode (reason: {reason:?}, app: {app_id:?}) → cookie {cookie}"
     );

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -148,6 +148,47 @@ fn cmd_restore(scx_loader: &LoaderClientProxyBlocking) -> Result<(), Box<dyn std
     Ok(())
 }
 
+fn cmd_hold(
+    scx_loader: &LoaderClientProxyBlocking,
+    sched_name: String,
+    mode: SchedMode,
+    reason: String,
+    app_id: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sched = validate_sched(scx_loader, sched_name);
+    let sched_str: &str = sched.clone().into();
+    let cookie = scx_loader.hold_scheduler(sched_str, mode as u32, &reason, &app_id)?;
+    println!(
+        "holding {sched:?} in {mode:?} mode (reason: {reason:?}, app: {app_id:?}) → cookie {cookie}"
+    );
+    Ok(())
+}
+
+fn cmd_release(
+    scx_loader: &LoaderClientProxyBlocking,
+    cookie: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    scx_loader.release_scheduler(cookie)?;
+    println!("released hold with cookie {cookie}");
+    Ok(())
+}
+
+fn cmd_holds(scx_loader: &LoaderClientProxyBlocking) -> Result<(), Box<dyn std::error::Error>> {
+    let holds = scx_loader.active_holds()?;
+    if holds.is_empty() {
+        println!("no active holds");
+    } else {
+        println!("{} active hold(s):", holds.len());
+        for h in &holds {
+            println!(
+                "  cookie={} scheduler={} mode={} reason={:?} app_id={:?}",
+                h.cookie, h.scheduler, h.mode, h.reason, h.app_id
+            );
+        }
+    }
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     let conn = Connection::system()?;
@@ -161,6 +202,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Stop => cmd_stop(&scx_loader)?,
         Commands::Restart => cmd_restart(&scx_loader)?,
         Commands::Restore => cmd_restore(&scx_loader)?,
+        Commands::Hold { args } => {
+            cmd_hold(&scx_loader, args.sched, args.mode, args.reason, args.app_id)?
+        }
+        Commands::Release { cookie } => cmd_release(&scx_loader, cookie)?,
+        Commands::Holds => cmd_holds(&scx_loader)?,
     }
 
     Ok(())


### PR DESCRIPTION
Clients that need to temporarily switch the active scheduler had no safe way to restore the previous state on cleanup, and concurrent clients would silently overwrite each other's scheduler choice.

Introduce HoldScheduler/ReleaseScheduler methods modelled after power-profiles-daemon's HoldProfile/ReleaseProfile API. Acquiring a hold activates the requested scheduler and returns an opaque cookie; the pre-hold state is saved automatically. Releasing the cookie restores it. Multiple concurrent holds are supported with last-write-wins semantics — releasing the active hold falls back to the next most recent one, and releasing the last hold restores the original state.

Active holds are exposed as a new ActiveHolds property for introspection.

scxctl gains hold, release, and holds subcommands to exercise the new interface from the command line.