### PR TITLE
scx_lavd: Tune per-mode flags

### DIFF
--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -36,11 +36,11 @@ powersave_mode = []
 server_mode = []
 
 [scheds.scx_lavd]
-auto_mode = ["--autopilot"]
-gaming_mode = ["--performance"]
-lowlatency_mode = ["--performance"]
-powersave_mode = ["--powersave"]
-server_mode = ["--autopilot"]
+auto_mode = ["--autopilot", "--pinned-slice-us", "500"]
+gaming_mode = ["--performance", "--pinned-slice-us", "500"]
+lowlatency_mode = ["--performance", "--pinned-slice-us", "500"]
+powersave_mode = ["--powersave", "--pinned-slice-us", "500"]
+server_mode = ["--performance", "--slice-min-us", "3000", "--slice-max-us", "10000", "--pinned-slice-us", "3000"]
 
 [scheds.scx_flash]
 auto_mode = []
@@ -139,9 +139,11 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_rusty`:
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_lavd`:
-    * Gaming mode: `--performance`
-    * Low Latency mode: `--performance`
-    * Power Save mode: `--powersave`
+    * Auto mode: `--autopilot --pinned-slice-us 500`
+    * Gaming mode: `--performance --pinned-slice-us 500`
+    * Low Latency mode: `--performance --pinned-slice-us 500`
+    * Power Save mode: `--powersave --pinned-slice-us 500`
+    * Server mode: `--performance --slice-min-us 3000 --slice-max-us 10000 --pinned-slice-us 3000`
 * For `scx_flash`:
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_tickless`:

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -211,9 +211,20 @@ fn get_default_scx_flags_for_mode(
             SchedMode::Auto => vec!["-m", "auto"],
         },
         SupportedSched::Lavd => match sched_mode {
-            SchedMode::Gaming | SchedMode::LowLatency => vec!["--performance"],
-            SchedMode::PowerSave => vec!["--powersave"],
-            SchedMode::Server | SchedMode::Auto => vec!["--autopilot"],
+            SchedMode::Gaming | SchedMode::LowLatency => {
+                vec!["--performance", "--pinned-slice-us", "500"]
+            }
+            SchedMode::PowerSave => vec!["--powersave", "--pinned-slice-us", "500"],
+            SchedMode::Server => vec![
+                "--performance",
+                "--slice-min-us",
+                "3000",
+                "--slice-max-us",
+                "10000",
+                "--pinned-slice-us",
+                "3000",
+            ],
+            SchedMode::Auto => vec!["--autopilot", "--pinned-slice-us", "500"],
         },
         SupportedSched::P2DQ => match sched_mode {
             SchedMode::Gaming => vec!["--task-slice", "true", "-f", "--sched-mode", "performance"],
@@ -285,11 +296,11 @@ powersave_mode = []
 server_mode = []
 
 [scheds.scx_lavd]
-auto_mode = ["--autopilot"]
-gaming_mode = ["--performance"]
-lowlatency_mode = ["--performance"]
-powersave_mode = ["--powersave"]
-server_mode = ["--autopilot"]
+auto_mode = ["--autopilot", "--pinned-slice-us", "500"]
+gaming_mode = ["--performance", "--pinned-slice-us", "500"]
+lowlatency_mode = ["--performance", "--pinned-slice-us", "500"]
+powersave_mode = ["--powersave", "--pinned-slice-us", "500"]
+server_mode = ["--performance", "--slice-min-us", "3000", "--slice-max-us", "10000", "--pinned-slice-us", "3000"]
 
 [scheds.scx_flash]
 auto_mode = []


### PR DESCRIPTION
Add --pinned-slice-us to all scx_lavd modes and rework Server mode to use --performance with explicit slice bounds.

- Auto:        --autopilot --pinned-slice-us 500
- Gaming:      --performance --pinned-slice-us 500
- LowLatency:  --performance --pinned-slice-us 500
- PowerSave:   --powersave --pinned-slice-us 500
- Server:      --performance --slice-min-us 3000 --slice-max-us 10000 --pinned-slice-us 3000

Updates the default-config test fixture and configuration.md to match.