### PR TITLE
scx_cosmos: Update profile options

### DIFF
--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -72,10 +72,10 @@ server_mode = []
 
 [scheds.scx_cosmos]
 auto_mode = []
-gaming_mode = ["-s", "700", "-S"]
-lowlatency_mode = ["-s", "700", "-S", "-m", "performance", "-w"]
+gaming_mode = ["-s", "700"]
+lowlatency_mode = ["-s", "700", "-m", "performance", "-w"]
 powersave_mode = ["-m", "powersave"]
-server_mode = ["-s", "20000", "-c", "75", "-p", "250"]
+server_mode = []
 
 [scheds.scx_beerland]
 auto_mode = []
@@ -159,10 +159,9 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_rustland`:
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_cosmos`:
-    * Gaming mode: `-s 700 -S`
-    * Low Latency mode: `-s 700 -S -m performance -w`
+    * Gaming mode: `-s 700`
+    * Low Latency mode: `-s 700 -m performance -w`
     * Power Save mode: `-m powersave`
-    * Server mode: `-s 20000 -c 75 -p 250`
 * For `scx_beerland`:
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_cake`:

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -241,11 +241,10 @@ fn get_default_scx_flags_for_mode(
             SchedMode::Auto => vec![],
         },
         SupportedSched::Cosmos => match sched_mode {
-            SchedMode::Gaming => vec!["-s", "700", "-S"],
-            SchedMode::LowLatency => vec!["-s", "700", "-S", "-m", "performance", "-w"],
+            SchedMode::Gaming => vec!["-s", "700"],
+            SchedMode::LowLatency => vec!["-s", "700", "-m", "performance", "-w"],
             SchedMode::PowerSave => vec!["-m", "powersave"],
-            SchedMode::Server => vec!["-s", "20000", "-c", "75", "-p", "250"],
-            SchedMode::Auto => vec![],
+            SchedMode::Server | SchedMode::Auto => vec![],
         },
         SupportedSched::Cake => match sched_mode {
             SchedMode::Gaming | SchedMode::Server => vec!["--profile", "gaming"],
@@ -332,10 +331,10 @@ server_mode = []
 
 [scheds.scx_cosmos]
 auto_mode = []
-gaming_mode = ["-s", "700", "-S"]
-lowlatency_mode = ["-s", "700", "-S", "-m", "performance", "-w"]
+gaming_mode = ["-s", "700"]
+lowlatency_mode = ["-s", "700", "-m", "performance", "-w"]
 powersave_mode = ["-m", "powersave"]
-server_mode = ["-s", "20000", "-c", "75", "-p", "250"]
+server_mode = []
 
 [scheds.scx_beerland]
 auto_mode = []


### PR DESCRIPTION
scx_cosmos has recently shifted its focus toward more CPU-intensive, server-oriented workloads, so the default options have also been changed to better match large server systems out of the box.

Update the options to match the expected performance profiles.

Link: https://github.com/sched-ext/scx/pull/3607