### PR TITLE
scx_loader: add scx_chaos, scx_layered, scx_mitosis, scx_rlfifo

### DIFF
--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -104,6 +104,13 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
+
+[scheds.scx_chaos]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 ```
 
 **`default_sched`:**
@@ -172,6 +179,8 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_pandemonium`:
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_flow`:
+    * No custom flags are defined, so the default flags for each mode will be used.
+* For `scx_chaos`:
     * No custom flags are defined, so the default flags for each mode will be used.
 
 ### Fallback Behavior

--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -118,6 +118,13 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
+
+[scheds.scx_mitosis]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 ```
 
 **`default_sched`:**
@@ -190,6 +197,8 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_chaos`:
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_layered`:
+    * No custom flags are defined, so the default flags for each mode will be used.
+* For `scx_mitosis`:
     * No custom flags are defined, so the default flags for each mode will be used.
 
 ### Fallback Behavior

--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -125,6 +125,13 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
+
+[scheds.scx_rlfifo]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 ```
 
 **`default_sched`:**
@@ -199,6 +206,8 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_layered`:
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_mitosis`:
+    * No custom flags are defined, so the default flags for each mode will be used.
+* For `scx_rlfifo`:
     * No custom flags are defined, so the default flags for each mode will be used.
 
 ### Fallback Behavior

--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -111,6 +111,13 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
+
+[scheds.scx_layered]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 ```
 
 **`default_sched`:**
@@ -181,6 +188,8 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_flow`:
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_chaos`:
+    * No custom flags are defined, so the default flags for each mode will be used.
+* For `scx_layered`:
     * No custom flags are defined, so the default flags for each mode will be used.
 
 ### Fallback Behavior

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -111,6 +111,7 @@ pub fn get_default_config() -> Config {
         SupportedSched::Flow,
         SupportedSched::Chaos,
         SupportedSched::Layered,
+        SupportedSched::Mitosis,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(init_default_config_entry));
     Config {
@@ -262,6 +263,7 @@ fn get_default_scx_flags_for_mode(
         | SupportedSched::Flash
         | SupportedSched::Chaos
         | SupportedSched::Layered
+        | SupportedSched::Mitosis
         | SupportedSched::Flow => vec![],
     }
 }
@@ -376,6 +378,13 @@ powersave_mode = []
 server_mode = []
 
 [scheds.scx_layered]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
+
+[scheds.scx_mitosis]
 auto_mode = []
 gaming_mode = []
 lowlatency_mode = []

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -109,6 +109,7 @@ pub fn get_default_config() -> Config {
         SupportedSched::Cake,
         SupportedSched::Pandemonium,
         SupportedSched::Flow,
+        SupportedSched::Chaos,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(init_default_config_entry));
     Config {
@@ -258,6 +259,7 @@ fn get_default_scx_flags_for_mode(
         | SupportedSched::Beerland
         | SupportedSched::Pandemonium
         | SupportedSched::Flash
+        | SupportedSched::Chaos
         | SupportedSched::Flow => vec![],
     }
 }
@@ -358,6 +360,13 @@ powersave_mode = []
 server_mode = []
 
 [scheds.scx_flow]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
+
+[scheds.scx_chaos]
 auto_mode = []
 gaming_mode = []
 lowlatency_mode = []

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -112,6 +112,7 @@ pub fn get_default_config() -> Config {
         SupportedSched::Chaos,
         SupportedSched::Layered,
         SupportedSched::Mitosis,
+        SupportedSched::Rlfifo,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(init_default_config_entry));
     Config {
@@ -264,6 +265,7 @@ fn get_default_scx_flags_for_mode(
         | SupportedSched::Chaos
         | SupportedSched::Layered
         | SupportedSched::Mitosis
+        | SupportedSched::Rlfifo
         | SupportedSched::Flow => vec![],
     }
 }
@@ -385,6 +387,13 @@ powersave_mode = []
 server_mode = []
 
 [scheds.scx_mitosis]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
+
+[scheds.scx_rlfifo]
 auto_mode = []
 gaming_mode = []
 lowlatency_mode = []

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -110,6 +110,7 @@ pub fn get_default_config() -> Config {
         SupportedSched::Pandemonium,
         SupportedSched::Flow,
         SupportedSched::Chaos,
+        SupportedSched::Layered,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(init_default_config_entry));
     Config {
@@ -260,6 +261,7 @@ fn get_default_scx_flags_for_mode(
         | SupportedSched::Pandemonium
         | SupportedSched::Flash
         | SupportedSched::Chaos
+        | SupportedSched::Layered
         | SupportedSched::Flow => vec![],
     }
 }
@@ -367,6 +369,13 @@ powersave_mode = []
 server_mode = []
 
 [scheds.scx_chaos]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
+
+[scheds.scx_layered]
 auto_mode = []
 gaming_mode = []
 lowlatency_mode = []

--- a/crates/scx_loader/src/lib.rs
+++ b/crates/scx_loader/src/lib.rs
@@ -44,6 +44,8 @@ pub enum SupportedSched {
     Pandemonium,
     #[serde(rename = "scx_flow")]
     Flow,
+    #[serde(rename = "scx_chaos")]
+    Chaos,
 }
 
 impl FromStr for SupportedSched {
@@ -54,6 +56,7 @@ impl FromStr for SupportedSched {
             "scx_beerland" => Ok(SupportedSched::Beerland),
             "scx_bpfland" => Ok(SupportedSched::Bpfland),
             "scx_cake" => Ok(SupportedSched::Cake),
+            "scx_chaos" => Ok(SupportedSched::Chaos),
             "scx_cosmos" => Ok(SupportedSched::Cosmos),
             "scx_flash" => Ok(SupportedSched::Flash),
             "scx_flow" => Ok(SupportedSched::Flow),
@@ -81,6 +84,7 @@ impl From<SupportedSched> for &str {
             SupportedSched::Beerland => "scx_beerland",
             SupportedSched::Bpfland => "scx_bpfland",
             SupportedSched::Cake => "scx_cake",
+            SupportedSched::Chaos => "scx_chaos",
             SupportedSched::Cosmos => "scx_cosmos",
             SupportedSched::Flash => "scx_flash",
             SupportedSched::Flow => "scx_flow",

--- a/crates/scx_loader/src/lib.rs
+++ b/crates/scx_loader/src/lib.rs
@@ -50,6 +50,8 @@ pub enum SupportedSched {
     Layered,
     #[serde(rename = "scx_mitosis")]
     Mitosis,
+    #[serde(rename = "scx_rlfifo")]
+    Rlfifo,
 }
 
 impl FromStr for SupportedSched {
@@ -70,6 +72,7 @@ impl FromStr for SupportedSched {
             "scx_pandemonium" => Ok(SupportedSched::Pandemonium),
             "scx_p2dq" => Ok(SupportedSched::P2DQ),
             "scx_tickless" => Ok(SupportedSched::Tickless),
+            "scx_rlfifo" => Ok(SupportedSched::Rlfifo),
             "scx_rustland" => Ok(SupportedSched::Rustland),
             "scx_rusty" => Ok(SupportedSched::Rusty),
             _ => Err(anyhow::anyhow!("{scx_name} is not supported")),
@@ -100,6 +103,7 @@ impl From<SupportedSched> for &str {
             SupportedSched::Pandemonium => "scx_pandemonium",
             SupportedSched::P2DQ => "scx_p2dq",
             SupportedSched::Tickless => "scx_tickless",
+            SupportedSched::Rlfifo => "scx_rlfifo",
             SupportedSched::Rustland => "scx_rustland",
             SupportedSched::Rusty => "scx_rusty",
         }

--- a/crates/scx_loader/src/lib.rs
+++ b/crates/scx_loader/src/lib.rs
@@ -48,6 +48,8 @@ pub enum SupportedSched {
     Chaos,
     #[serde(rename = "scx_layered")]
     Layered,
+    #[serde(rename = "scx_mitosis")]
+    Mitosis,
 }
 
 impl FromStr for SupportedSched {
@@ -64,6 +66,7 @@ impl FromStr for SupportedSched {
             "scx_flow" => Ok(SupportedSched::Flow),
             "scx_lavd" => Ok(SupportedSched::Lavd),
             "scx_layered" => Ok(SupportedSched::Layered),
+            "scx_mitosis" => Ok(SupportedSched::Mitosis),
             "scx_pandemonium" => Ok(SupportedSched::Pandemonium),
             "scx_p2dq" => Ok(SupportedSched::P2DQ),
             "scx_tickless" => Ok(SupportedSched::Tickless),
@@ -93,6 +96,7 @@ impl From<SupportedSched> for &str {
             SupportedSched::Flow => "scx_flow",
             SupportedSched::Lavd => "scx_lavd",
             SupportedSched::Layered => "scx_layered",
+            SupportedSched::Mitosis => "scx_mitosis",
             SupportedSched::Pandemonium => "scx_pandemonium",
             SupportedSched::P2DQ => "scx_p2dq",
             SupportedSched::Tickless => "scx_tickless",

--- a/crates/scx_loader/src/lib.rs
+++ b/crates/scx_loader/src/lib.rs
@@ -46,6 +46,8 @@ pub enum SupportedSched {
     Flow,
     #[serde(rename = "scx_chaos")]
     Chaos,
+    #[serde(rename = "scx_layered")]
+    Layered,
 }
 
 impl FromStr for SupportedSched {
@@ -61,6 +63,7 @@ impl FromStr for SupportedSched {
             "scx_flash" => Ok(SupportedSched::Flash),
             "scx_flow" => Ok(SupportedSched::Flow),
             "scx_lavd" => Ok(SupportedSched::Lavd),
+            "scx_layered" => Ok(SupportedSched::Layered),
             "scx_pandemonium" => Ok(SupportedSched::Pandemonium),
             "scx_p2dq" => Ok(SupportedSched::P2DQ),
             "scx_tickless" => Ok(SupportedSched::Tickless),
@@ -89,6 +92,7 @@ impl From<SupportedSched> for &str {
             SupportedSched::Flash => "scx_flash",
             SupportedSched::Flow => "scx_flow",
             SupportedSched::Lavd => "scx_lavd",
+            SupportedSched::Layered => "scx_layered",
             SupportedSched::Pandemonium => "scx_pandemonium",
             SupportedSched::P2DQ => "scx_p2dq",
             SupportedSched::Tickless => "scx_tickless",

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -114,6 +114,7 @@ impl ScxLoader {
             "scx_beerland",
             "scx_bpfland",
             "scx_cake",
+            "scx_chaos",
             "scx_cosmos",
             "scx_flash",
             "scx_flow",

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -119,6 +119,7 @@ impl ScxLoader {
             "scx_flash",
             "scx_flow",
             "scx_lavd",
+            "scx_layered",
             "scx_pandemonium",
             "scx_p2dq",
             "scx_tickless",

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -120,6 +120,7 @@ impl ScxLoader {
             "scx_flow",
             "scx_lavd",
             "scx_layered",
+            "scx_mitosis",
             "scx_pandemonium",
             "scx_p2dq",
             "scx_tickless",

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -124,6 +124,7 @@ impl ScxLoader {
             "scx_pandemonium",
             "scx_p2dq",
             "scx_tickless",
+            "scx_rlfifo",
             "scx_rustland",
             "scx_rusty",
         ]


### PR DESCRIPTION
This patch adds support for the remaining rust scx scheds which are missing support in `scx-loader`.

I tested loading each of them with `scxctl`, all of which ran properly. Let me know if more testing is wanted.