### PR TITLE
scx_loader/scxctl: improved profile support 

### DIFF
--- a/configs/org.scx.Loader.conf
+++ b/configs/org.scx.Loader.conf
@@ -59,6 +59,10 @@
                send_interface="org.scx.Loader"
                send_member="RestoreDefault"/>
 
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="SchedulerModes"/>
+
         <allow receive_sender="org.scx.Loader"/>
     </policy>
 

--- a/configs/org.scx.Loader.xml
+++ b/configs/org.scx.Loader.xml
@@ -66,6 +66,29 @@
     <property name="DefaultMode" type="u" access="read"/>
 
     <!--
+        SchedulerModes:
+
+        Returns the scheduler modes that are meaningfully configured for the
+        given scheduler, i.e. the modes that resolve to a non-empty argument
+        list. Auto (0) is always included, since it represents the
+        scheduler's own defaults and is valid even without explicit
+        arguments.
+
+        Clients can use this to discover ahead of time which modes will
+        actually change scheduler behavior, rather than finding out only
+        after starting/switching to a mode that has no effect.
+
+        @scx_name: The name of the scheduler to query (e.g., "scx_rusty").
+        @sched_modes: An array of scheduler modes (see the SchedulerMode
+                    property for the meaning of each value) that are
+                    meaningfully configured for this scheduler.
+    -->
+    <method name="SchedulerModes">
+      <arg name="scx_name" type="s" direction="in"/>
+      <arg name="sched_modes" type="au" direction="out"/>
+    </method>
+
+    <!--
         StartScheduler:
 
         Starts the specified scheduler with the given mode.

--- a/crates/scx_loader/README.md
+++ b/crates/scx_loader/README.md
@@ -12,6 +12,9 @@
 * **`CurrentScheduler` Property:** Returns the `scx_name` of the active scheduler or "unknown" if none is running.
 * **`SchedulerMode` Property:** Provides information about the currently active scheduler's mode (profile).
 * **`SupportedSchedulers` Property:**  Lists the schedulers currently supported by `scx_loader`.
+* **`SchedulerModes` Method:** Given a `scx_name`, returns the modes that are actually configured (i.e. resolve to a non-empty argument list) for that scheduler. `Auto` is always included. Use this to check ahead of time whether a mode you're about to select will have any effect.
+
+**Note on modes without configured arguments:** Selecting a non-`Auto` mode that has no configured arguments (neither in the config file nor as a hardcoded default) is not treated as an error. `scx_loader` will start/switch/restart the scheduler as requested, using its own built-in defaults, and will log a warning noting that the requested mode had no effect. Use `SchedulerModes` beforehand if you want to avoid this situation entirely.
 
 ## Usage
 
@@ -68,6 +71,14 @@
   ```bash
   dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.freedesktop.DBus.Properties.Get string:org.scx.Loader string:SupportedSchedulers
   ```
+
+* **Get the Configured Modes for a Scheduler:**
+
+  ```bash
+  dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.SchedulerModes string:scx_lavd
+  ```
+
+  (This returns the modes that actually do something for `scx_lavd`, e.g. `[0, 1, 2, 4]` if `LowLatency` has no configured arguments)
 
 **Note:** Replace the example scheduler names and arguments with the actual ones you want to use.
 

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use crate::SchedMode;
 use crate::SupportedSched;
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub default_sched: Option<SupportedSched>,
@@ -24,7 +24,7 @@ pub struct Config {
     pub scheds: HashMap<String, Sched>,
 }
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Sched {
     pub auto_mode: Option<Vec<String>>,
     pub gaming_mode: Option<Vec<String>>,
@@ -264,6 +264,45 @@ fn get_default_scx_flags_for_mode(
     }
 }
 
+/// All scheduler modes, in a stable order used for enumeration.
+const ALL_MODES: [SchedMode; 5] = [
+    SchedMode::Auto,
+    SchedMode::Gaming,
+    SchedMode::PowerSave,
+    SchedMode::LowLatency,
+    SchedMode::Server,
+];
+
+/// Returns `true` if selecting `sched_mode` for `scx_sched` would resolve to an
+/// empty argument list, meaning the mode wouldn't actually change how the
+/// scheduler behaves (it would just run with its own built-in defaults).
+///
+/// `Auto` is never considered to be lacking args: it represents the
+/// scheduler's own defaults, so an empty argument list is expected and fine.
+#[must_use]
+pub fn mode_lacks_args(config: &Config, scx_sched: &SupportedSched, sched_mode: SchedMode) -> bool {
+    if sched_mode == SchedMode::Auto {
+        return false;
+    }
+
+    get_scx_flags_for_mode(config, scx_sched, sched_mode).is_empty()
+}
+
+/// Returns the modes that are meaningfully configured for `scx_sched`, i.e.
+/// the modes that resolve to a non-empty argument list. `Auto` is always
+/// included, since it is valid even without explicit arguments.
+///
+/// This lets clients (e.g. `scxctl`) discover ahead of time which modes will
+/// actually change scheduler behavior for a given scheduler, instead of
+/// `scx_loader` hard-rejecting "unconfigured" modes.
+#[must_use]
+pub fn get_configured_modes(config: &Config, scx_sched: &SupportedSched) -> Vec<SchedMode> {
+    ALL_MODES
+        .into_iter()
+        .filter(|&mode| !mode_lacks_args(config, scx_sched, mode))
+        .collect()
+}
+
 /// Initializes entry for config sched map
 fn init_default_config_entry(scx_sched: SupportedSched) -> (String, Sched) {
     let default_modes = get_default_sched_for_config(&scx_sched);
@@ -351,5 +390,76 @@ auto_mode = ["--help"]
         let config_str = "";
         let result = parse_config_content(config_str);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_auto_mode_never_lacks_args() {
+        let config_str = r"
+[scheds.scx_lavd]
+auto_mode = []
+";
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+
+        assert!(!mode_lacks_args(
+            &parsed_config,
+            &SupportedSched::Lavd,
+            SchedMode::Auto
+        ));
+    }
+
+    #[test]
+    fn test_mode_lacks_args_when_explicitly_empty() {
+        let config_str = r"
+[scheds.scx_lavd]
+gaming_mode = []
+";
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+
+        assert!(mode_lacks_args(
+            &parsed_config,
+            &SupportedSched::Lavd,
+            SchedMode::Gaming
+        ));
+    }
+
+    #[test]
+    fn test_mode_lacks_args_falls_back_to_defaults() {
+        // scx_rusty doesn't define any hardcoded mode flags, so every non-auto
+        // mode resolves to an empty argument list unless the user configures one.
+        let parsed_config = get_default_config();
+
+        assert!(mode_lacks_args(
+            &parsed_config,
+            &SupportedSched::Rusty,
+            SchedMode::Gaming
+        ));
+        // scx_lavd does define hardcoded flags for gaming mode.
+        assert!(!mode_lacks_args(
+            &parsed_config,
+            &SupportedSched::Lavd,
+            SchedMode::Gaming
+        ));
+    }
+
+    #[test]
+    fn test_get_configured_modes() {
+        let config_str = r#"
+[scheds.scx_cake]
+auto_mode = ["--profile", "default"]
+gaming_mode = []
+lowlatency_mode = ["--profile", "esports"]
+powersave_mode = ["--profile", "battery"]
+server_mode = []
+"#;
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+
+        let configured_modes = get_configured_modes(&parsed_config, &SupportedSched::Cake);
+
+        // Auto is always included, LowLatency/PowerSave were explicitly given
+        // non-empty args, but Gaming/Server were explicitly emptied out.
+        assert_eq!(
+            configured_modes,
+            vec![SchedMode::Auto, SchedMode::PowerSave, SchedMode::LowLatency]
+        );
     }
 }

--- a/crates/scx_loader/src/dbus.rs
+++ b/crates/scx_loader/src/dbus.rs
@@ -87,4 +87,10 @@ pub trait LoaderClient {
     /// Defaults to 0 (Auto) if not explicitly configured.
     #[zbus(property)]
     fn default_mode(&self) -> zbus::Result<SchedMode>;
+
+    /// Returns the scheduler modes that are meaningfully configured for
+    /// `scx_name`, i.e. the modes that resolve to a non-empty argument list.
+    /// `Auto` is always included, since it represents the scheduler's own
+    /// defaults and is valid even without explicit arguments.
+    fn scheduler_modes(&self, scx_name: SupportedSched) -> zbus::Result<Vec<SchedMode>>;
 }

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -70,6 +70,9 @@ struct ScxLoader {
     // Store default configuration from config file
     default_sched: Option<SupportedSched>,
     default_mode: SchedMode,
+    // Full config, kept around so clients can query which modes are actually
+    // configured for a given scheduler (see `scheduler_modes`).
+    config: config::Config,
 }
 
 #[derive(Parser, Debug)]
@@ -142,6 +145,24 @@ impl ScxLoader {
     #[zbus(property)]
     fn default_mode(&self) -> SchedMode {
         self.default_mode
+    }
+
+    /// Returns the scheduler modes that are meaningfully configured for
+    /// `scx_name`, i.e. the modes that resolve to a non-empty argument list.
+    /// `Auto` is always included, since it's valid even without explicit
+    /// arguments.
+    ///
+    /// Clients can use this to discover ahead of time which modes will
+    /// actually change scheduler behavior, rather than finding out only
+    /// after starting/switching to a mode that has no effect.
+    ///
+    /// This has to stay `async`, even though it never awaits anything: zbus's
+    /// `#[interface]` macro deserializes arguments of sync methods by
+    /// reference where possible, and `SupportedSched` (unlike e.g. `&str`)
+    /// only implements `Deserialize` by value, not by reference.
+    #[allow(clippy::unused_async)]
+    async fn scheduler_modes(&self, scx_name: SupportedSched) -> Vec<SchedMode> {
+        config::get_configured_modes(&self.config, &scx_name)
     }
 
     async fn start_scheduler(
@@ -412,6 +433,7 @@ async fn main() -> Result<()> {
                 channel: channel.clone(),
                 default_sched: config.default_sched.clone(),
                 default_mode: config.default_mode.unwrap_or(SchedMode::Auto),
+                config: config.clone(),
             },
         )
         .await?;
@@ -478,6 +500,11 @@ async fn worker_loop(
 
                 // get scheduler args for the mode
                 let args = config::get_scx_flags_for_mode(&config, &scx_sched, sched_mode);
+                if config::mode_lacks_args(&config, &scx_sched, sched_mode) {
+                    log::warn!(
+                        "starting {scx_sched:?} in {sched_mode:?} mode, but no arguments are configured for this mode; scheduler will run with its own defaults and the requested mode has no effect"
+                    );
+                }
 
                 // send message with scheduler and asociated args to the runner
                 runner_tx
@@ -497,6 +524,11 @@ async fn worker_loop(
 
                 // get scheduler args for the mode
                 let args = config::get_scx_flags_for_mode(&config, &scx_sched, sched_mode);
+                if config::mode_lacks_args(&config, &scx_sched, sched_mode) {
+                    log::warn!(
+                        "switching {scx_sched:?} to {sched_mode:?} mode, but no arguments are configured for this mode; scheduler will run with its own defaults and the requested mode has no effect"
+                    );
+                }
 
                 // send message with scheduler and asociated args to the runner
                 runner_tx
@@ -520,6 +552,11 @@ async fn worker_loop(
                     args
                 } else {
                     // Use mode-based arguments
+                    if config::mode_lacks_args(&config, &scx_sched, current_mode) {
+                        log::warn!(
+                            "restarting {scx_sched:?} in {current_mode:?} mode, but no arguments are configured for this mode; scheduler will run with its own defaults and the requested mode has no effect"
+                        );
+                    }
                     config::get_scx_flags_for_mode(&config, &scx_sched, current_mode)
                 };
 

--- a/crates/scxctl/README.md
+++ b/crates/scxctl/README.md
@@ -33,6 +33,7 @@ Usage: scxctl <COMMAND>
 Commands:
   get      Get the current scheduler and mode
   list     List all supported schedulers
+  modes    List the modes that are actually configured for a scheduler
   start    Start a scheduler in a mode or with arguments
   switch   Switch schedulers or modes, optionally with arguments
   stop     Stop the current scheduler
@@ -96,4 +97,10 @@ Switch to flash and increase the maximum time slice from 4ms (default) to 20ms
 
 ```
 scxctl switch -s flash -a="-s,20000"
+```
+
+Check scheduler modes
+
+```
+scxctl modes -s lavd
 ```

--- a/crates/scxctl/src/cli.rs
+++ b/crates/scxctl/src/cli.rs
@@ -57,12 +57,23 @@ pub struct SwitchArgs {
     pub args: Option<Vec<String>>,
 }
 
+#[derive(Parser, Debug)]
+pub struct ModesArgs {
+    #[arg(short, long, help = "Scheduler to query", required = true)]
+    pub sched: String,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     #[command(about = "Get the info on the running scheduler")]
     Get,
     #[command(about = "List all supported schedulers")]
     List,
+    #[command(about = "List the modes that are actually configured for a scheduler")]
+    Modes {
+        #[clap(flatten)]
+        args: ModesArgs,
+    },
     #[command(about = "Start a scheduler in a mode or with arguments")]
     Start {
         #[clap(flatten)]

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -45,6 +45,17 @@ fn cmd_list(scx_loader: &LoaderClientProxyBlocking) {
     }
 }
 
+fn cmd_modes(
+    scx_loader: &LoaderClientProxyBlocking,
+    sched_name: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sched: SupportedSched = validate_sched(scx_loader, sched_name);
+    let modes: Vec<SchedMode> = scx_loader.scheduler_modes(sched.clone())?;
+    println!("modes configured for {sched:?}: {modes:?}");
+    println!("(any mode not listed here has no configured arguments and would just run {sched:?} with its own defaults)");
+    Ok(())
+}
+
 fn cmd_start(
     scx_loader: &LoaderClientProxyBlocking,
     sched_name: String,
@@ -156,6 +167,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Get => cmd_get(&scx_loader)?,
         Commands::List => cmd_list(&scx_loader),
+        Commands::Modes { args } => cmd_modes(&scx_loader, args.sched)?,
         Commands::Start { args } => cmd_start(&scx_loader, args.sched, args.mode, args.args)?,
         Commands::Switch { args } => cmd_switch(&scx_loader, args.sched, args.mode, args.args)?,
         Commands::Stop => cmd_stop(&scx_loader)?,

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -119,7 +119,7 @@ fn cmd_start(
         println!("started {sched:?} in {mode:?} mode");
     } else {
         scx_loader.start_scheduler(sched.clone(), mode)?;
-        println!("started {sched:?} with its own defaults");
+        println!("started {sched:?} (running with default scheduler arguments)");
     }
     Ok(())
 }
@@ -161,7 +161,7 @@ fn cmd_switch(
         println!("switched to {sched:?} in {mode:?} mode");
     } else {
         scx_loader.switch_scheduler(sched.clone(), mode)?;
-        println!("switched to {sched:?} with its own defaults");
+        println!("switched to {sched:?} (running with default scheduler arguments)");
     }
     Ok(())
 }

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -142,12 +142,26 @@ fn cmd_switch(
         exit(1);
     }
 
+    let current_sched_name = scx_loader.current_scheduler().unwrap();
     let sched: SupportedSched = match sched_name {
         Some(sched_name) => validate_sched(scx_loader, sched_name),
-        None => SupportedSched::try_from(scx_loader.current_scheduler().unwrap().as_str()).unwrap(),
+        None => SupportedSched::try_from(current_sched_name.as_str()).unwrap(),
     };
+
+    // Whether this switch is actually changing to a different scheduler, as
+    // opposed to just changing the mode of the one already running.
+    let target_sched_name: &str = sched.clone().into();
+    let switching_scheduler = target_sched_name != current_sched_name;
+
     let mode: SchedMode = match mode_name {
         Some(mode_name) => mode_name,
+        // Only inherit the currently active mode when switching within the
+        // same scheduler. Switching to a *different* scheduler without an
+        // explicit -m should start it fresh in Auto mode, rather than
+        // silently carrying over a mode picked for the scheduler being
+        // switched away from (which this new scheduler may not even have
+        // configured).
+        None if switching_scheduler => SchedMode::Auto,
         None => scx_loader.scheduler_mode().unwrap(),
     };
     if let Some(args) = args {

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -56,6 +56,41 @@ fn cmd_modes(
     Ok(())
 }
 
+/// Checks whether `mode` has configured arguments for `sched`, warning the
+/// user if it doesn't, and returns whether it does.
+///
+/// `scx_loader` itself only logs the "no configured args" case server-side
+/// (e.g. to the systemd journal), which an interactive `scxctl` user would
+/// never see. This makes the same check client-side, using the
+/// `SchedulerModes` method, so the person running `scxctl start`/`switch`
+/// actually finds out that the mode they picked has no effect, instead of
+/// scxctl claiming a mode was applied when nothing about it actually changed
+/// scheduler behavior.
+fn check_mode_configured(
+    scx_loader: &LoaderClientProxyBlocking,
+    sched: &SupportedSched,
+    mode: SchedMode,
+) -> bool {
+    if mode == SchedMode::Auto {
+        return true;
+    }
+
+    // If the query itself fails, don't block the actual start/switch on it;
+    // just skip the warning and let scx_loader do what it would do anyway.
+    let Ok(configured_modes) = scx_loader.scheduler_modes(sched.clone()) else {
+        return true;
+    };
+
+    let is_configured = configured_modes.contains(&mode);
+    if !is_configured {
+        println!(
+            "{} {sched:?} has no configured arguments for {mode:?} mode; it will run with its own defaults",
+            "warning:".yellow().bold()
+        );
+    }
+    is_configured
+}
+
 fn cmd_start(
     scx_loader: &LoaderClientProxyBlocking,
     sched_name: String,
@@ -79,9 +114,12 @@ fn cmd_start(
     if let Some(args) = args {
         scx_loader.start_scheduler_with_args(sched.clone(), &args.clone())?;
         println!("started {sched:?} with arguments \"{}\"", args.join(" "));
-    } else {
+    } else if check_mode_configured(scx_loader, &sched, mode) {
         scx_loader.start_scheduler(sched.clone(), mode)?;
         println!("started {sched:?} in {mode:?} mode");
+    } else {
+        scx_loader.start_scheduler(sched.clone(), mode)?;
+        println!("started {sched:?} with its own defaults");
     }
     Ok(())
 }
@@ -118,9 +156,12 @@ fn cmd_switch(
             "switched to {sched:?} with arguments \"{}\"",
             args.join(" ")
         );
-    } else {
+    } else if check_mode_configured(scx_loader, &sched, mode) {
         scx_loader.switch_scheduler(sched.clone(), mode)?;
         println!("switched to {sched:?} in {mode:?} mode");
+    } else {
+        scx_loader.switch_scheduler(sched.clone(), mode)?;
+        println!("switched to {sched:?} with its own defaults");
     }
     Ok(())
 }


### PR DESCRIPTION
PR introduces improved profile support for scx_loader and scxctl. The first step is to implement profile detection—to determine which profiles have been configured.

```
lucjan at cachyos ~ 8:57:11    
❯ scxctl modes -s lavd                           
modes configured for Lavd: [Auto, Gaming, PowerSave, LowLatency, Server]
(any mode not listed here has no configured arguments and would just run Lavd with its own defaults)
lucjan at cachyos ~ 8:57:16    
❯ scxctl modes -s flash
modes configured for Flash: [Auto]
(any mode not listed here has no configured arguments and would just run Flash with its own defaults)
lucjan at cachyos ~ 8:57:24    
❯ scxctl modes -s p2dq 
modes configured for P2DQ: [Auto, Gaming, PowerSave, LowLatency, Server]
(any mode not listed here has no configured arguments and would just run P2DQ with its own defaults)
lucjan at cachyos ~ 8:57:30    
❯ scxctl modes -s bpfland
modes configured for Bpfland: [Auto, Gaming, PowerSave, LowLatency, Server]
(any mode not listed here has no configured arguments and would simply run Bpfland with its own defaults)
lucjan at cachyos ~ 8:57:45    
❯ scxctl modes -s cosmos 
modes configured for Cosmos: [Auto, Gaming, PowerSave, LowLatency]
(any mode not listed here has no configured arguments and would simply run Cosmos with its own defaults)
```

In the second step, a warning was displayed stating that the profile does not exist, and the scheduler will start in default mode. 

```
lucjan at cachyos ~ 8:58:17    
❯ scxctl start -s flash -m lowlatency            
warning: Flash has no configured arguments for LowLatency mode; it will run with its own defaults
started Flash (running with default scheduler arguments)
```

This will provide the user with a little more information about the available options and inform them that the scheduler does not have any profiles and will run in automode. 