### PR TITLE
scx_loader/scxctl: improved profile support part 2

### DIFF
--- a/configs/org.scx.Loader.conf
+++ b/configs/org.scx.Loader.conf
@@ -63,6 +63,10 @@
                send_interface="org.scx.Loader"
                send_member="SchedulerModes"/>
 
+        <allow send_destination="org.scx.Loader"
+               send_interface="org.scx.Loader"
+               send_member="SchedulerModeArgs"/>
+
         <allow receive_sender="org.scx.Loader"/>
     </policy>
 

--- a/configs/org.scx.Loader.xml
+++ b/configs/org.scx.Loader.xml
@@ -89,6 +89,28 @@
     </method>
 
     <!--
+        SchedulerModeArgs:
+
+        Returns the resolved arguments for every mode of the given
+        scheduler, in a stable order. A mode with no configured arguments
+        comes back with an empty array, meaning it would just run the
+        scheduler with its own built-in defaults for that mode.
+
+        Unlike SchedulerModes, this returns every mode together with its
+        actual arguments, so clients can show the exact configuration
+        instead of just which modes are configured.
+
+        @scx_name: The name of the scheduler to query (e.g., "scx_rusty").
+        @mode_args: An array of (mode, arguments) pairs, one per scheduler
+                    mode (see the SchedulerMode property for the meaning of
+                    each mode value).
+    -->
+    <method name="SchedulerModeArgs">
+      <arg name="scx_name" type="s" direction="in"/>
+      <arg name="mode_args" type="a(uas)" direction="out"/>
+    </method>
+
+    <!--
         StartScheduler:
 
         Starts the specified scheduler with the given mode.

--- a/crates/scx_loader/README.md
+++ b/crates/scx_loader/README.md
@@ -13,6 +13,7 @@
 * **`SchedulerMode` Property:** Provides information about the currently active scheduler's mode (profile).
 * **`SupportedSchedulers` Property:**  Lists the schedulers currently supported by `scx_loader`.
 * **`SchedulerModes` Method:** Given a `scx_name`, returns the modes that are actually configured (i.e. resolve to a non-empty argument list) for that scheduler. `Auto` is always included. Use this to check ahead of time whether a mode you're about to select will have any effect.
+* **`SchedulerModeArgs` Method:** Given a `scx_name`, returns the resolved arguments for *every* mode of that scheduler (not just the configured ones), so you can see the exact configuration instead of just which modes have an effect.
 
 **Note on modes without configured arguments:** Selecting a non-`Auto` mode that has no configured arguments (neither in the config file nor as a hardcoded default) is not treated as an error. `scx_loader` will start/switch/restart the scheduler as requested, using its own built-in defaults, and will log a warning noting that the requested mode had no effect. Use `SchedulerModes` beforehand if you want to avoid this situation entirely.
 
@@ -79,6 +80,14 @@
   ```
 
   (This returns the modes that actually do something for `scx_lavd`, e.g. `[0, 1, 2, 4]` if `LowLatency` has no configured arguments)
+
+* **Get the Resolved Arguments for Every Mode of a Scheduler:**
+
+  ```bash
+  dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.SchedulerModeArgs string:scx_lavd
+  ```
+
+  (This returns every mode paired with its actual arguments, e.g. `LowLatency` coming back with an empty array if it has no configured arguments)
 
 **Note:** Replace the example scheduler names and arguments with the actual ones you want to use.
 

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -303,6 +303,26 @@ pub fn get_configured_modes(config: &Config, scx_sched: &SupportedSched) -> Vec<
         .collect()
 }
 
+/// Returns the resolved arguments for every mode of `scx_sched`, in a stable
+/// order. Modes with no configured arguments come back with an empty `Vec`,
+/// meaning the scheduler would just run with its own built-in defaults for
+/// that mode.
+///
+/// Unlike `get_configured_modes`, this includes every mode (not just the
+/// ones that resolve to non-empty args) along with its actual arguments, so
+/// callers (e.g. `scxctl modes --show`) can display the exact configuration
+/// instead of just which modes are configured.
+#[must_use]
+pub fn get_all_mode_args(
+    config: &Config,
+    scx_sched: &SupportedSched,
+) -> Vec<(SchedMode, Vec<String>)> {
+    ALL_MODES
+        .into_iter()
+        .map(|mode| (mode, get_scx_flags_for_mode(config, scx_sched, mode)))
+        .collect()
+}
+
 /// Initializes entry for config sched map
 fn init_default_config_entry(scx_sched: SupportedSched) -> (String, Sched) {
     let default_modes = get_default_sched_for_config(&scx_sched);
@@ -460,6 +480,46 @@ server_mode = []
         assert_eq!(
             configured_modes,
             vec![SchedMode::Auto, SchedMode::PowerSave, SchedMode::LowLatency]
+        );
+    }
+
+    #[test]
+    fn test_get_all_mode_args() {
+        let config_str = r#"
+[scheds.scx_cake]
+auto_mode = ["--profile", "default"]
+gaming_mode = []
+powersave_mode = ["--profile", "battery"]
+lowlatency_mode = ["--profile", "esports"]
+server_mode = ["--profile", "gaming"]
+"#;
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+
+        let mode_args = get_all_mode_args(&parsed_config, &SupportedSched::Cake);
+
+        // Every mode is present, in a stable order, with its actual
+        // resolved arguments (explicit, hardcoded-default, or empty).
+        assert_eq!(
+            mode_args,
+            vec![
+                (
+                    SchedMode::Auto,
+                    vec!["--profile".to_owned(), "default".to_owned()]
+                ),
+                (SchedMode::Gaming, vec![]),
+                (
+                    SchedMode::PowerSave,
+                    vec!["--profile".to_owned(), "battery".to_owned()]
+                ),
+                (
+                    SchedMode::LowLatency,
+                    vec!["--profile".to_owned(), "esports".to_owned()]
+                ),
+                (
+                    SchedMode::Server,
+                    vec!["--profile".to_owned(), "gaming".to_owned()]
+                ),
+            ]
         );
     }
 }

--- a/crates/scx_loader/src/dbus.rs
+++ b/crates/scx_loader/src/dbus.rs
@@ -93,4 +93,13 @@ pub trait LoaderClient {
     /// `Auto` is always included, since it represents the scheduler's own
     /// defaults and is valid even without explicit arguments.
     fn scheduler_modes(&self, scx_name: SupportedSched) -> zbus::Result<Vec<SchedMode>>;
+
+    /// Returns the resolved arguments for every mode of `scx_name`, in a
+    /// stable order. A mode with no configured arguments comes back with an
+    /// empty list, meaning it would just run `scx_name` with its own
+    /// built-in defaults.
+    fn scheduler_mode_args(
+        &self,
+        scx_name: SupportedSched,
+    ) -> zbus::Result<Vec<(SchedMode, Vec<String>)>>;
 }

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -165,6 +165,21 @@ impl ScxLoader {
         config::get_configured_modes(&self.config, &scx_name)
     }
 
+    /// Returns the resolved arguments for every mode of `scx_name`, in a
+    /// stable order. A mode with no configured arguments comes back with an
+    /// empty list, meaning it would just run `scx_name` with its own
+    /// built-in defaults.
+    ///
+    /// Unlike `SchedulerModes`, this returns every mode together with its
+    /// actual arguments, so clients can show the exact configuration
+    /// instead of just which modes are configured.
+    ///
+    /// See `scheduler_modes` for why this has to stay `async`.
+    #[allow(clippy::unused_async)]
+    async fn scheduler_mode_args(&self, scx_name: SupportedSched) -> Vec<(SchedMode, Vec<String>)> {
+        config::get_all_mode_args(&self.config, &scx_name)
+    }
+
     async fn start_scheduler(
         &mut self,
         #[zbus(connection)] conn: &Connection,

--- a/crates/scxctl/src/cli.rs
+++ b/crates/scxctl/src/cli.rs
@@ -61,6 +61,11 @@ pub struct SwitchArgs {
 pub struct ModesArgs {
     #[arg(short, long, help = "Scheduler to query", required = true)]
     pub sched: String,
+    #[arg(
+        long,
+        help = "Show the resolved arguments for every mode, not just which ones are configured"
+    )]
+    pub show: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/scxctl/src/cli.rs
+++ b/crates/scxctl/src/cli.rs
@@ -65,7 +65,7 @@ pub struct ModesArgs {
         long,
         help = "Show the resolved arguments for every mode, not just which ones are configured"
     )]
-    pub show: bool,
+    pub show_args: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -48,11 +48,11 @@ fn cmd_list(scx_loader: &LoaderClientProxyBlocking) {
 fn cmd_modes(
     scx_loader: &LoaderClientProxyBlocking,
     sched_name: String,
-    show: bool,
+    show_args: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sched: SupportedSched = validate_sched(scx_loader, sched_name);
 
-    if show {
+    if show_args {
         let mode_args: Vec<(SchedMode, Vec<String>)> =
             scx_loader.scheduler_mode_args(sched.clone())?;
         println!("configuration for {sched:?}:");
@@ -66,7 +66,7 @@ fn cmd_modes(
     } else {
         let modes: Vec<SchedMode> = scx_loader.scheduler_modes(sched.clone())?;
         println!("modes configured for {sched:?}: {modes:?}");
-        println!("(unlisted modes run with {sched:?}'s own defaults; use --show to see them all)");
+        println!("(unlisted modes run with {sched:?}'s own defaults; use --show-args to see them all)");
     }
     Ok(())
 }
@@ -237,7 +237,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Get => cmd_get(&scx_loader)?,
         Commands::List => cmd_list(&scx_loader),
-        Commands::Modes { args } => cmd_modes(&scx_loader, args.sched, args.show)?,
+        Commands::Modes { args } => cmd_modes(&scx_loader, args.sched, args.show_args)?,
         Commands::Start { args } => cmd_start(&scx_loader, args.sched, args.mode, args.args)?,
         Commands::Switch { args } => cmd_switch(&scx_loader, args.sched, args.mode, args.args)?,
         Commands::Stop => cmd_stop(&scx_loader)?,

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -48,11 +48,27 @@ fn cmd_list(scx_loader: &LoaderClientProxyBlocking) {
 fn cmd_modes(
     scx_loader: &LoaderClientProxyBlocking,
     sched_name: String,
+    show: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sched: SupportedSched = validate_sched(scx_loader, sched_name);
-    let modes: Vec<SchedMode> = scx_loader.scheduler_modes(sched.clone())?;
-    println!("modes configured for {sched:?}: {modes:?}");
-    println!("(any mode not listed here has no configured arguments and would just run {sched:?} with its own defaults)");
+
+    if show {
+        let mode_args: Vec<(SchedMode, Vec<String>)> =
+            scx_loader.scheduler_mode_args(sched.clone())?;
+        println!("configuration for {sched:?}:");
+        for (mode, args) in mode_args {
+            if args.is_empty() {
+                println!("  {mode:?}: (not configured, runs with {sched:?}'s own defaults)");
+            } else {
+                println!("  {mode:?}: {}", args.join(" "));
+            }
+        }
+    } else {
+        let modes: Vec<SchedMode> = scx_loader.scheduler_modes(sched.clone())?;
+        println!("modes configured for {sched:?}: {modes:?}");
+        println!("(any mode not listed here has no configured arguments and would just run {sched:?} with its own defaults)");
+        println!("(use --show to see the resolved arguments for every mode)");
+    }
     Ok(())
 }
 
@@ -222,7 +238,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Get => cmd_get(&scx_loader)?,
         Commands::List => cmd_list(&scx_loader),
-        Commands::Modes { args } => cmd_modes(&scx_loader, args.sched)?,
+        Commands::Modes { args } => cmd_modes(&scx_loader, args.sched, args.show)?,
         Commands::Start { args } => cmd_start(&scx_loader, args.sched, args.mode, args.args)?,
         Commands::Switch { args } => cmd_switch(&scx_loader, args.sched, args.mode, args.args)?,
         Commands::Stop => cmd_stop(&scx_loader)?,

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -66,8 +66,7 @@ fn cmd_modes(
     } else {
         let modes: Vec<SchedMode> = scx_loader.scheduler_modes(sched.clone())?;
         println!("modes configured for {sched:?}: {modes:?}");
-        println!("(any mode not listed here has no configured arguments and would just run {sched:?} with its own defaults)");
-        println!("(use --show to see the resolved arguments for every mode)");
+        println!("(unlisted modes run with {sched:?}'s own defaults; use --show to see them all)");
     }
     Ok(())
 }


### PR DESCRIPTION
`scxctl modes -s <sched>` only lists which modes are configured, not what they're actually configured to. Add a `--show` flag that prints the resolved arguments for every mode (including ones that fall back to a scheduler's own defaults), backed by a new SchedulerModeArgs D-Bus method mirroring SchedulerModes but returning (mode, args) pairs for all modes instead of just the configured ones.

Kept as a separate method rather than changing SchedulerModes' return type, to avoid a breaking change for existing callers.

```
lucjan at cachyos ~ 12:44:55    
❯ scxctl modes -s rusty                          
modes configured for Rusty: [Auto]
(any mode not listed here has no configured arguments and would just run Rusty with its own defaults)
(use --show to see the resolved arguments for every mode)
lucjan at cachyos ~ 12:44:59    
❯ scxctl modes -s rusty --show
configuration for Rusty:
  Auto: (not configured, runs with Rusty's own defaults)
  Gaming: (not configured, runs with Rusty's own defaults)
  PowerSave: (not configured, runs with Rusty's own defaults)
  LowLatency: (not configured, runs with Rusty's own defaults)
  Server: (not configured, runs with Rusty's own defaults)
lucjan at cachyos ~ 12:45:04    
❯ scxctl modes -s cosmos       
modes configured for Cosmos: [Auto, Gaming, PowerSave, LowLatency]
(any mode not listed here has no configured arguments and would just run Cosmos with its own defaults)
(use --show to see the resolved arguments for every mode)
lucjan at cachyos ~ 12:45:13    
❯ scxctl modes -s cosmos --show
configuration for Cosmos:
  Auto: (not configured, runs with Cosmos's own defaults)
  Gaming: -s 700
  PowerSave: -m powersave
  LowLatency: -s 700 -m performance -w
  Server: (not configured, runs with Cosmos's own defaults)
```

Custom user configurations are also supported. 

```
lucjan at cachyos ~ 12:46:35    
❯ scxctl modes -s rusty                          
modes configured for Rusty: [Auto, LowLatency]
(any mode not listed here has no configured arguments and would just run Rusty with its own defaults)
(use --show to see the resolved arguments for every mode)
lucjan at cachyos ~ 12:46:37    
❯ scxctl modes -s rusty --show                   
configuration for Rusty:
  Auto: (not configured, runs with Rusty's own defaults)
  Gaming: (not configured, runs with Rusty's own defaults)
  PowerSave: (not configured, runs with Rusty's own defaults)
  LowLatency: --direct-greedy-under 1
  Server: (not configured, runs with Rusty's own defaults)
```