### PR TITLE
scxctl: fix clippy error

### DIFF
--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -278,7 +278,7 @@ fn validate_sched(scx_loader: &LoaderClientProxyBlocking, sched: String) -> Supp
         println!(
             "{} invalid value '{}' for '{}'",
             "error:".red().bold(),
-            &sched.yellow(),
+            sched.yellow(),
             "--sched <SCHED>".bold()
         );
         println!("supported schedulers: {supported_scheds:?}");


### PR DESCRIPTION
Rust 1.97 caused errors with `cargo clippy` 

```
❯ cargo clippy --all-targets --all-features -- -D warnings
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.46
   Compiling unicode-ident v1.0.24
    Checking pin-project-lite v0.2.17
   Compiling serde v1.0.228
   Compiling libc v0.2.186
   Compiling crossbeam-utils v0.8.21
   Compiling serde_core v1.0.228
    Checking bitflags v2.13.0
    Checking parking v2.2.1
   Compiling rustix v1.1.4
   Compiling winnow v1.0.3
    Checking futures-core v0.3.32
    Checking linux-raw-sys v0.12.1
   Compiling equivalent v1.0.2
   Compiling hashbrown v0.17.1
   Compiling toml_datetime v1.1.1+spec-1.1.0
    Checking futures-io v0.3.32
    Checking fastrand v2.4.1
    Checking cfg-if v1.0.4
   Compiling autocfg v1.5.1
    Checking utf8parse v0.2.2
    Checking slab v0.4.12
   Compiling endi v1.1.1
    Checking anstyle-parse v1.0.0
    Checking anstyle-query v1.1.5
    Checking futures-lite v2.6.1
    Checking anstyle v1.0.14
    Checking colorchoice v1.0.5
    Checking async-task v4.7.1
    Checking is_terminal_polyfill v1.70.2
   Compiling cfg_aliases v0.2.1
    Checking strsim v0.11.1
   Compiling heck v0.5.0
    Checking anstream v1.0.0
    Checking concurrent-queue v2.5.0
    Checking once_cell v1.21.4
    Checking clap_lex v1.1.0
   Compiling async-io v2.6.0
   Compiling anyhow v1.0.103
    Checking unicode-width v0.2.2
    Checking event-listener v5.4.1
    Checking bytes v1.12.0
    Checking atomic-waker v1.1.2
   Compiling indexmap v2.14.0
    Checking syn v2.0.118
    Checking unicase v2.9.0
    Checking piper v0.2.5
    Checking event-listener-strategy v0.5.4
    Checking tracing-core v0.1.36
   Compiling nix v0.31.3
    Checking async-channel v2.5.0
    Checking async-lock v3.4.2
    Checking toml_writer v1.1.1+spec-1.1.0
    Checking async-executor v1.14.0
    Checking blocking v1.6.2
    Checking async-broadcast v0.7.2
    Checking ordered-stream v0.2.0
    Checking hex v0.4.3
    Checking static_assertions v1.1.0
    Checking futures-sink v0.3.32
    Checking memchr v2.8.2
   Compiling toml_parser v1.1.2+spec-1.1.0
    Checking colored v3.1.1
    Checking log v0.4.33
   Compiling toml_edit v0.25.12+spec-1.1.0
    Checking errno v0.3.14
    Checking mio v1.2.1
    Checking socket2 v0.6.4
    Checking sysinfo v0.39.5
    Checking signal-hook-registry v1.4.8
    Checking serde_spanned v1.1.1
    Checking uuid v1.23.4
   Compiling proc-macro-crate v3.5.0
    Checking ctrlc v3.5.2
    Checking toml v1.1.2+spec-1.1.0
   Compiling serde_derive v1.0.228
   Compiling enumflags2_derive v0.7.12
   Compiling tokio-macros v2.7.0
   Compiling clap_derive v4.6.1
   Compiling tracing-attributes v0.1.31
   Compiling async-trait v0.1.89
   Compiling serde_repr v0.1.20
   Compiling async-recursion v1.1.1
    Checking tokio v1.52.3
    Checking polling v3.11.0
    Checking terminal_size v0.4.4
    Checking clap_builder v4.6.0
    Checking tracing v0.1.44
    Checking async-signal v0.2.14
    Checking async-process v2.5.0
    Checking clap v4.6.1
    Checking enumflags2 v0.7.12
    Checking zvariant_utils v3.4.0
    Checking xtask v0.1.0 (/home/lucjan/Pobrane/scx-loader/xtask)
   Compiling zvariant_derive v5.12.0
   Compiling zvariant v5.12.0
    Checking tokio-util v0.7.18
    Checking zbus_names v4.3.2
   Compiling zbus_macros v5.16.0
    Checking zbus v5.16.0
    Checking zbus_polkit v5.0.0
    Checking scx_loader v1.1.2 (/home/lucjan/Pobrane/scx-loader/crates/scx_loader)
    Checking scxctl v1.1.2 (/home/lucjan/Pobrane/scx-loader/crates/scxctl)
error: redundant reference in `println!` argument
   --> crates/scxctl/src/main.rs:281:13
    |
281 |             &sched.yellow(),
    |             ^^^^^^^^^^^^^^^ help: remove the redundant `&`: `sched.yellow()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
    = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`

error: could not compile `scxctl` (bin "scxctl") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `scxctl` (bin "scxctl" test) due to 1 previous error
'cargo clippy --all-targets --all-features -- -D warnings' time: 10,014s, cpu: 476%
lucjan at cachyos ~/Pobrane/scx-loader 8:01:17 cabfa931 main    
❯ cargo clippy --all-targets --all-features -- -D warnings
    Checking scxctl v1.1.2 (/home/lucjan/Pobrane/scx-loader/crates/scxctl)
error: redundant reference in `println!` argument
   --> crates/scxctl/src/main.rs:281:13
    |
281 |             &sched.yellow(),
    |             ^^^^^^^^^^^^^^^ help: remove the redundant `&`: `sched.yellow()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
    = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`

error: could not compile `scxctl` (bin "scxctl") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `scxctl` (bin "scxctl" test) due to 1 previous error
```

The current PR seems to address this problem

```
❯ cargo clippy --all-targets --all-features -- -D warnings
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.46
   Compiling unicode-ident v1.0.24
   Compiling serde v1.0.228
    Checking pin-project-lite v0.2.17
   Compiling libc v0.2.186
   Compiling serde_core v1.0.228
   Compiling crossbeam-utils v0.8.21
    Checking bitflags v2.13.0
    Checking parking v2.2.1
   Compiling rustix v1.1.4
   Compiling winnow v1.0.3
    Checking futures-core v0.3.32
    Checking linux-raw-sys v0.12.1
   Compiling equivalent v1.0.2
   Compiling hashbrown v0.17.1
   Compiling toml_datetime v1.1.1+spec-1.1.0
    Checking fastrand v2.4.1
    Checking futures-io v0.3.32
    Checking cfg-if v1.0.4
   Compiling autocfg v1.5.1
    Checking slab v0.4.12
    Checking utf8parse v0.2.2
    Checking anstyle v1.0.14
    Checking futures-lite v2.6.1
    Checking anstyle-parse v1.0.0
    Checking anstyle-query v1.1.5
    Checking colorchoice v1.0.5
    Checking async-task v4.7.1
    Checking is_terminal_polyfill v1.70.2
   Compiling endi v1.1.1
    Checking anstream v1.0.0
   Compiling anyhow v1.0.103
   Compiling heck v0.5.0
    Checking atomic-waker v1.1.2
    Checking concurrent-queue v2.5.0
    Checking bytes v1.12.0
   Compiling cfg_aliases v0.2.1
   Compiling async-io v2.6.0
    Checking unicode-width v0.2.2
    Checking clap_lex v1.1.0
    Checking event-listener v5.4.1
    Checking once_cell v1.21.4
   Compiling indexmap v2.14.0
    Checking unicase v2.9.0
    Checking strsim v0.11.1
    Checking syn v2.0.118
    Checking event-listener-strategy v0.5.4
    Checking tracing-core v0.1.36
   Compiling nix v0.31.3
    Checking piper v0.2.5
    Checking async-channel v2.5.0
    Checking async-lock v3.4.2
    Checking toml_writer v1.1.1+spec-1.1.0
    Checking async-executor v1.14.0
    Checking async-broadcast v0.7.2
    Checking blocking v1.6.2
    Checking ordered-stream v0.2.0
    Checking hex v0.4.3
    Checking futures-sink v0.3.32
    Checking memchr v2.8.2
    Checking toml_parser v1.1.2+spec-1.1.0
    Checking static_assertions v1.1.0
    Checking colored v3.1.1
    Checking log v0.4.33
   Compiling toml_edit v0.25.12+spec-1.1.0
    Checking errno v0.3.14
    Checking mio v1.2.1
    Checking socket2 v0.6.4
    Checking sysinfo v0.39.5
    Checking signal-hook-registry v1.4.8
    Checking serde_spanned v1.1.1
    Checking uuid v1.23.4
   Compiling proc-macro-crate v3.5.0
    Checking ctrlc v3.5.2
    Checking toml v1.1.2+spec-1.1.0
   Compiling serde_derive v1.0.228
   Compiling enumflags2_derive v0.7.12
   Compiling tokio-macros v2.7.0
   Compiling tracing-attributes v0.1.31
   Compiling clap_derive v4.6.1
   Compiling serde_repr v0.1.20
   Compiling async-trait v0.1.89
   Compiling async-recursion v1.1.1
    Checking polling v3.11.0
    Checking terminal_size v0.4.4
    Checking clap_builder v4.6.0
    Checking tokio v1.52.3
    Checking async-signal v0.2.14
    Checking tracing v0.1.44
    Checking async-process v2.5.0
    Checking clap v4.6.1
    Checking zvariant_utils v3.4.0
    Checking enumflags2 v0.7.12
    Checking xtask v0.1.0 (/home/lucjan/Pobrane/a/scx-loader/xtask)
   Compiling zvariant_derive v5.12.0
   Compiling zvariant v5.12.0
    Checking tokio-util v0.7.18
    Checking zbus_names v4.3.2
   Compiling zbus_macros v5.16.0
    Checking zbus v5.16.0
    Checking zbus_polkit v5.0.0
    Checking scx_loader v1.1.2 (/home/lucjan/Pobrane/a/scx-loader/crates/scx_loader)
    Checking scxctl v1.1.2 (/home/lucjan/Pobrane/a/scx-loader/crates/scxctl)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.21s
'cargo clippy --all-targets --all-features -- -D warnings' time: 9,251s, cpu: 495%
```