### PR TITLE
scx_loader/scxctl: improved profile support part 3

### DIFF
--- a/configs/org.scx.Loader.xml
+++ b/configs/org.scx.Loader.xml
@@ -75,8 +75,8 @@
         arguments.
 
         Clients can use this to discover ahead of time which modes will
-        actually change scheduler behavior, rather than finding out only
-        after starting/switching to a mode that has no effect.
+        have mode-specific arguments applied, rather than finding out only
+        after starting/switching that no such arguments are configured.
 
         @scx_name: The name of the scheduler to query (e.g., "scx_rusty").
         @sched_modes: An array of scheduler modes (see the SchedulerMode

--- a/crates/scx_loader/README.md
+++ b/crates/scx_loader/README.md
@@ -12,10 +12,10 @@
 * **`CurrentScheduler` Property:** Returns the `scx_name` of the active scheduler or "unknown" if none is running.
 * **`SchedulerMode` Property:** Provides information about the currently active scheduler's mode (profile).
 * **`SupportedSchedulers` Property:**  Lists the schedulers currently supported by `scx_loader`.
-* **`SchedulerModes` Method:** Given a `scx_name`, returns the modes that are actually configured (i.e. resolve to a non-empty argument list) for that scheduler. `Auto` is always included. Use this to check ahead of time whether a mode you're about to select will have any effect.
-* **`SchedulerModeArgs` Method:** Given a `scx_name`, returns the resolved arguments for *every* mode of that scheduler (not just the configured ones), so you can see the exact configuration instead of just which modes have an effect.
+* **`SchedulerModes` Method:** Given a `scx_name`, returns the modes that are actually configured (i.e. resolve to a non-empty argument list) for that scheduler. `Auto` is always included. Use this to check ahead of time whether selecting a mode will apply any mode-specific arguments.
+* **`SchedulerModeArgs` Method:** Given a `scx_name`, returns the resolved arguments for *every* mode of that scheduler (not just the configured ones), so you can see the exact configuration instead of only which modes have mode-specific arguments.
 
-**Note on modes without configured arguments:** Selecting a non-`Auto` mode that has no configured arguments (neither in the config file nor as a hardcoded default) is not treated as an error. `scx_loader` will start/switch/restart the scheduler as requested, using its own built-in defaults, and will log a warning noting that the requested mode had no effect. Use `SchedulerModes` beforehand if you want to avoid this situation entirely.
+**Note on modes without configured arguments:** Selecting a non-`Auto` mode that has no configured arguments (neither in the config file nor as a hardcoded default) is not treated as an error. `scx_loader` will start/switch/restart the scheduler as requested, using its own built-in defaults, and will log a warning noting that no mode-specific arguments were applied. Use `SchedulerModes` beforehand if you want to avoid this situation entirely.
 
 ## Usage
 

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -153,8 +153,8 @@ impl ScxLoader {
     /// arguments.
     ///
     /// Clients can use this to discover ahead of time which modes will
-    /// actually change scheduler behavior, rather than finding out only
-    /// after starting/switching to a mode that has no effect.
+    /// have mode-specific arguments applied, rather than finding out only
+    /// after starting/switching that no such arguments are configured.
     ///
     /// This has to stay `async`, even though it never awaits anything: zbus's
     /// `#[interface]` macro deserializes arguments of sync methods by
@@ -517,7 +517,7 @@ async fn worker_loop(
                 let args = config::get_scx_flags_for_mode(&config, &scx_sched, sched_mode);
                 if config::mode_lacks_args(&config, &scx_sched, sched_mode) {
                     log::warn!(
-                        "starting {scx_sched:?} in {sched_mode:?} mode, but no arguments are configured for this mode; scheduler will run with its own defaults and the requested mode has no effect"
+                        "starting {scx_sched:?} in {sched_mode:?} mode, but no mode-specific arguments are configured; the scheduler will run with its own defaults"
                     );
                 }
 
@@ -541,7 +541,7 @@ async fn worker_loop(
                 let args = config::get_scx_flags_for_mode(&config, &scx_sched, sched_mode);
                 if config::mode_lacks_args(&config, &scx_sched, sched_mode) {
                     log::warn!(
-                        "switching {scx_sched:?} to {sched_mode:?} mode, but no arguments are configured for this mode; scheduler will run with its own defaults and the requested mode has no effect"
+                        "switching {scx_sched:?} to {sched_mode:?} mode, but no mode-specific arguments are configured; the scheduler will run with its own defaults"
                     );
                 }
 
@@ -569,7 +569,7 @@ async fn worker_loop(
                     // Use mode-based arguments
                     if config::mode_lacks_args(&config, &scx_sched, current_mode) {
                         log::warn!(
-                            "restarting {scx_sched:?} in {current_mode:?} mode, but no arguments are configured for this mode; scheduler will run with its own defaults and the requested mode has no effect"
+                            "restarting {scx_sched:?} in {current_mode:?} mode, but no mode-specific arguments are configured; the scheduler will run with its own defaults"
                         );
                     }
                     config::get_scx_flags_for_mode(&config, &scx_sched, current_mode)

--- a/crates/scxctl/README.md
+++ b/crates/scxctl/README.md
@@ -104,3 +104,9 @@ Check scheduler modes
 ```
 scxctl modes -s lavd
 ```
+
+Show the resolved arguments for every mode
+
+```
+scxctl modes -s lavd --show-args
+```

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -195,14 +195,20 @@ fn cmd_switch(
     }
 
     let current_sched = SupportedSched::try_from(current_sched_name.as_str())?;
-    let sched: SupportedSched = match sched_name {
-        Some(sched_name) => validate_sched(scx_loader, sched_name),
-        None => current_sched.clone(),
-    };
 
     // Whether this switch is actually changing to a different scheduler, as
-    // opposed to just changing the mode of the one already running.
-    let switching_scheduler = sched != current_sched;
+    // opposed to just changing the mode of the one already running. Resolved
+    // alongside `sched` so the `None` branch (no `-s` given) can move
+    // `current_sched` straight through instead of cloning it just to satisfy
+    // a comparison whose answer is already known to be `false`.
+    let (sched, switching_scheduler): (SupportedSched, bool) = match sched_name {
+        Some(sched_name) => {
+            let sched = validate_sched(scx_loader, sched_name);
+            let switching_scheduler = sched != current_sched;
+            (sched, switching_scheduler)
+        }
+        None => (current_sched, false),
+    };
 
     let mode = resolve_switch_mode(mode_name, switching_scheduler, || {
         scx_loader.scheduler_mode()

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -146,7 +146,12 @@ fn cmd_start(
 /// Prints the outcome of a start/switch operation, noting whether the
 /// requested mode actually had configured arguments applied or the
 /// scheduler fell back to its own defaults.
-fn report_mode_result(action: &str, sched: &SupportedSched, mode: SchedMode, mode_configured: bool) {
+fn report_mode_result(
+    action: &str,
+    sched: &SupportedSched,
+    mode: SchedMode,
+    mode_configured: bool,
+) {
     if mode_configured {
         println!("{action} {sched:?} in {mode:?} mode");
     } else {
@@ -316,9 +321,13 @@ mod tests {
 
     #[test]
     fn switch_to_different_scheduler_defaults_to_auto() {
-        let mode = resolve_switch_mode(None, true, || -> Result<SchedMode, Box<dyn std::error::Error>> {
-            panic!("current mode should not be fetched when switching scheduler")
-        })
+        let mode = resolve_switch_mode(
+            None,
+            true,
+            || -> Result<SchedMode, Box<dyn std::error::Error>> {
+                panic!("current mode should not be fetched when switching scheduler")
+            },
+        )
         .unwrap();
         assert_eq!(mode, SchedMode::Auto);
     }

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -138,24 +138,35 @@ fn cmd_start(
     } else {
         let mode_configured = check_mode_configured(scx_loader, &sched, mode);
         scx_loader.start_scheduler(sched.clone(), mode)?;
-        if mode_configured {
-            println!("started {sched:?} in {mode:?} mode");
-        } else {
-            println!("started {sched:?} with its own defaults");
-        }
+        report_mode_result("started", &sched, mode, mode_configured);
     }
     Ok(())
 }
 
-fn resolve_switch_mode(
+/// Prints the outcome of a start/switch operation, noting whether the
+/// requested mode actually had configured arguments applied or the
+/// scheduler fell back to its own defaults.
+fn report_mode_result(action: &str, sched: &SupportedSched, mode: SchedMode, mode_configured: bool) {
+    if mode_configured {
+        println!("{action} {sched:?} in {mode:?} mode");
+    } else {
+        println!("{action} {sched:?} with its own defaults");
+    }
+}
+
+/// Resolves which mode a `switch` should use. The current mode is fetched
+/// lazily via `fetch_current_mode` so that callers only pay for the D-Bus
+/// round-trip when it's actually needed (no explicit mode was requested and
+/// we're not switching to a different scheduler).
+fn resolve_switch_mode<E>(
     requested_mode: Option<SchedMode>,
-    current_mode: SchedMode,
     switching_scheduler: bool,
-) -> SchedMode {
+    fetch_current_mode: impl FnOnce() -> Result<SchedMode, E>,
+) -> Result<SchedMode, E> {
     match requested_mode {
-        Some(mode) => mode,
-        None if switching_scheduler => SchedMode::Auto,
-        None => current_mode,
+        Some(mode) => Ok(mode),
+        None if switching_scheduler => Ok(SchedMode::Auto),
+        None => fetch_current_mode(),
     }
 }
 
@@ -188,14 +199,9 @@ fn cmd_switch(
     // opposed to just changing the mode of the one already running.
     let switching_scheduler = sched != current_sched;
 
-    // The current mode is only needed when neither a mode nor a different
-    // scheduler was selected. Avoid an unnecessary D-Bus call otherwise.
-    let current_mode = if mode_name.is_none() && !switching_scheduler {
-        scx_loader.scheduler_mode()?
-    } else {
-        SchedMode::Auto
-    };
-    let mode = resolve_switch_mode(mode_name, current_mode, switching_scheduler);
+    let mode = resolve_switch_mode(mode_name, switching_scheduler, || {
+        scx_loader.scheduler_mode()
+    })?;
     if let Some(args) = args {
         scx_loader.switch_scheduler_with_args(sched.clone(), &args.clone())?;
         println!(
@@ -205,11 +211,7 @@ fn cmd_switch(
     } else {
         let mode_configured = check_mode_configured(scx_loader, &sched, mode);
         scx_loader.switch_scheduler(sched.clone(), mode)?;
-        if mode_configured {
-            println!("switched to {sched:?} in {mode:?} mode");
-        } else {
-            println!("switched to {sched:?} with its own defaults");
-        }
+        report_mode_result("switched to", &sched, mode, mode_configured);
     }
     Ok(())
 }
@@ -314,25 +316,32 @@ mod tests {
 
     #[test]
     fn switch_to_different_scheduler_defaults_to_auto() {
-        assert_eq!(
-            resolve_switch_mode(None, SchedMode::Gaming, true),
-            SchedMode::Auto
-        );
+        let mode = resolve_switch_mode(None, true, || -> Result<SchedMode, Box<dyn std::error::Error>> {
+            panic!("current mode should not be fetched when switching scheduler")
+        })
+        .unwrap();
+        assert_eq!(mode, SchedMode::Auto);
     }
 
     #[test]
     fn switch_within_same_scheduler_keeps_current_mode() {
-        assert_eq!(
-            resolve_switch_mode(None, SchedMode::Gaming, false),
-            SchedMode::Gaming
-        );
+        let mode: SchedMode = resolve_switch_mode(None, false, || {
+            Ok::<_, Box<dyn std::error::Error>>(SchedMode::Gaming)
+        })
+        .unwrap();
+        assert_eq!(mode, SchedMode::Gaming);
     }
 
     #[test]
     fn explicit_switch_mode_always_wins() {
-        assert_eq!(
-            resolve_switch_mode(Some(SchedMode::PowerSave), SchedMode::Gaming, true),
-            SchedMode::PowerSave
-        );
+        let mode = resolve_switch_mode(
+            Some(SchedMode::PowerSave),
+            true,
+            || -> Result<SchedMode, Box<dyn std::error::Error>> {
+                panic!("current mode should not be fetched when an explicit mode is given")
+            },
+        )
+        .unwrap();
+        assert_eq!(mode, SchedMode::PowerSave);
     }
 }

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -119,7 +119,8 @@ fn cmd_start(
     args: Option<Vec<String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Verify scx_loader is not running a scheduler
-    if scx_loader.current_scheduler().unwrap() != "unknown" {
+    let current_scheduler = scx_loader.current_scheduler()?;
+    if current_scheduler != "unknown" {
         println!(
             "{} scx scheduler already running, use '{}' instead of '{}'",
             "error:".red().bold(),

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -133,7 +133,7 @@ fn cmd_start(
     let sched: SupportedSched = validate_sched(scx_loader, sched_name);
     let mode: SchedMode = mode_name.unwrap_or(SchedMode::Auto);
     if let Some(args) = args {
-        scx_loader.start_scheduler_with_args(sched.clone(), &args.clone())?;
+        scx_loader.start_scheduler_with_args(sched.clone(), &args)?;
         println!("started {sched:?} with arguments \"{}\"", args.join(" "));
     } else {
         let mode_configured = check_mode_configured(scx_loader, &sched, mode);
@@ -208,7 +208,7 @@ fn cmd_switch(
         scx_loader.scheduler_mode()
     })?;
     if let Some(args) = args {
-        scx_loader.switch_scheduler_with_args(sched.clone(), &args.clone())?;
+        scx_loader.switch_scheduler_with_args(sched.clone(), &args)?;
         println!(
             "switched to {sched:?} with arguments \"{}\"",
             args.join(" ")

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -58,7 +58,11 @@ fn cmd_modes(
         println!("configuration for {sched:?}:");
         for (mode, args) in mode_args {
             if args.is_empty() {
-                println!("  {mode:?}: (not configured, runs with {sched:?}'s own defaults)");
+                if mode == SchedMode::Auto {
+                    println!("  {mode:?}: (uses {sched:?}'s own defaults)");
+                } else {
+                    println!("  {mode:?}: (not configured, uses {sched:?}'s own defaults)");
+                }
             } else {
                 println!("  {mode:?}: {}", args.join(" "));
             }
@@ -80,9 +84,9 @@ fn cmd_modes(
 /// (e.g. to the systemd journal), which an interactive `scxctl` user would
 /// never see. This makes the same check client-side, using the
 /// `SchedulerModes` method, so the person running `scxctl start`/`switch`
-/// actually finds out that the mode they picked has no effect, instead of
-/// scxctl claiming a mode was applied when nothing about it actually changed
-/// scheduler behavior.
+/// actually finds out that no mode-specific arguments will be applied,
+/// instead of scxctl implying that the selected mode has a dedicated
+/// configuration when it does not.
 fn check_mode_configured(
     scx_loader: &LoaderClientProxyBlocking,
     sched: &SupportedSched,
@@ -100,7 +104,7 @@ fn check_mode_configured(
 
     let is_configured = configured_modes.contains(&mode);
     if !is_configured {
-        println!(
+        eprintln!(
             "{} {sched:?} has no configured arguments for {mode:?} mode; it will run with its own defaults",
             "warning:".yellow().bold()
         );
@@ -131,14 +135,28 @@ fn cmd_start(
     if let Some(args) = args {
         scx_loader.start_scheduler_with_args(sched.clone(), &args.clone())?;
         println!("started {sched:?} with arguments \"{}\"", args.join(" "));
-    } else if check_mode_configured(scx_loader, &sched, mode) {
-        scx_loader.start_scheduler(sched.clone(), mode)?;
-        println!("started {sched:?} in {mode:?} mode");
     } else {
+        let mode_configured = check_mode_configured(scx_loader, &sched, mode);
         scx_loader.start_scheduler(sched.clone(), mode)?;
-        println!("started {sched:?} (running with default scheduler arguments)");
+        if mode_configured {
+            println!("started {sched:?} in {mode:?} mode");
+        } else {
+            println!("started {sched:?} with its own defaults");
+        }
     }
     Ok(())
+}
+
+fn resolve_switch_mode(
+    requested_mode: Option<SchedMode>,
+    current_mode: SchedMode,
+    switching_scheduler: bool,
+) -> SchedMode {
+    match requested_mode {
+        Some(mode) => mode,
+        None if switching_scheduler => SchedMode::Auto,
+        None => current_mode,
+    }
 }
 
 fn cmd_switch(
@@ -148,7 +166,8 @@ fn cmd_switch(
     args: Option<Vec<String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Verify scx_loader is running a scheduler
-    if scx_loader.current_scheduler().unwrap() == "unknown" {
+    let current_sched_name = scx_loader.current_scheduler()?;
+    if current_sched_name == "unknown" {
         println!(
             "{} no scx scheduler running, use '{}' instead of '{}'",
             "error:".red().bold(),
@@ -159,40 +178,38 @@ fn cmd_switch(
         exit(1);
     }
 
-    let current_sched_name = scx_loader.current_scheduler().unwrap();
+    let current_sched = SupportedSched::try_from(current_sched_name.as_str())?;
     let sched: SupportedSched = match sched_name {
         Some(sched_name) => validate_sched(scx_loader, sched_name),
-        None => SupportedSched::try_from(current_sched_name.as_str()).unwrap(),
+        None => current_sched.clone(),
     };
 
     // Whether this switch is actually changing to a different scheduler, as
     // opposed to just changing the mode of the one already running.
-    let target_sched_name: &str = sched.clone().into();
-    let switching_scheduler = target_sched_name != current_sched_name;
+    let switching_scheduler = sched != current_sched;
 
-    let mode: SchedMode = match mode_name {
-        Some(mode_name) => mode_name,
-        // Only inherit the currently active mode when switching within the
-        // same scheduler. Switching to a *different* scheduler without an
-        // explicit -m should start it fresh in Auto mode, rather than
-        // silently carrying over a mode picked for the scheduler being
-        // switched away from (which this new scheduler may not even have
-        // configured).
-        None if switching_scheduler => SchedMode::Auto,
-        None => scx_loader.scheduler_mode().unwrap(),
+    // The current mode is only needed when neither a mode nor a different
+    // scheduler was selected. Avoid an unnecessary D-Bus call otherwise.
+    let current_mode = if mode_name.is_none() && !switching_scheduler {
+        scx_loader.scheduler_mode()?
+    } else {
+        SchedMode::Auto
     };
+    let mode = resolve_switch_mode(mode_name, current_mode, switching_scheduler);
     if let Some(args) = args {
         scx_loader.switch_scheduler_with_args(sched.clone(), &args.clone())?;
         println!(
             "switched to {sched:?} with arguments \"{}\"",
             args.join(" ")
         );
-    } else if check_mode_configured(scx_loader, &sched, mode) {
-        scx_loader.switch_scheduler(sched.clone(), mode)?;
-        println!("switched to {sched:?} in {mode:?} mode");
     } else {
+        let mode_configured = check_mode_configured(scx_loader, &sched, mode);
         scx_loader.switch_scheduler(sched.clone(), mode)?;
-        println!("switched to {sched:?} (running with default scheduler arguments)");
+        if mode_configured {
+            println!("switched to {sched:?} in {mode:?} mode");
+        } else {
+            println!("switched to {sched:?} with its own defaults");
+        }
     }
     Ok(())
 }
@@ -289,4 +306,33 @@ fn validate_sched(scx_loader: &LoaderClientProxyBlocking, sched: String) -> Supp
     }
 
     SupportedSched::try_from(ensure_scx_prefix(sched).as_str()).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn switch_to_different_scheduler_defaults_to_auto() {
+        assert_eq!(
+            resolve_switch_mode(None, SchedMode::Gaming, true),
+            SchedMode::Auto
+        );
+    }
+
+    #[test]
+    fn switch_within_same_scheduler_keeps_current_mode() {
+        assert_eq!(
+            resolve_switch_mode(None, SchedMode::Gaming, false),
+            SchedMode::Gaming
+        );
+    }
+
+    #[test]
+    fn explicit_switch_mode_always_wins() {
+        assert_eq!(
+            resolve_switch_mode(Some(SchedMode::PowerSave), SchedMode::Gaming, true),
+            SchedMode::PowerSave
+        );
+    }
 }

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -66,7 +66,9 @@ fn cmd_modes(
     } else {
         let modes: Vec<SchedMode> = scx_loader.scheduler_modes(sched.clone())?;
         println!("modes configured for {sched:?}: {modes:?}");
-        println!("(unlisted modes run with {sched:?}'s own defaults; use --show-args to see them all)");
+        println!(
+            "(unlisted modes run with {sched:?}'s own defaults; use --show-args to see them all)"
+        );
     }
     Ok(())
 }

--- a/crates/scxctl/src/main.rs
+++ b/crates/scxctl/src/main.rs
@@ -18,7 +18,8 @@ fn cmd_get(scx_loader: &LoaderClientProxyBlocking) -> Result<(), Box<dyn std::er
 
         if current_args.is_empty() {
             let sched_mode: SchedMode = scx_loader.scheduler_mode()?;
-            println!("running {sched:?} in {sched_mode:?} mode");
+            let mode_configured = mode_is_configured(scx_loader, &sched, sched_mode);
+            report_mode_result("running", &sched, sched_mode, mode_configured);
         } else {
             println!(
                 "running {sched:?} with arguments \"{}\"",
@@ -87,7 +88,12 @@ fn cmd_modes(
 /// actually finds out that no mode-specific arguments will be applied,
 /// instead of scxctl implying that the selected mode has a dedicated
 /// configuration when it does not.
-fn check_mode_configured(
+/// Returns whether `mode` has configured arguments for `sched`.
+///
+/// `Auto` always counts as configured (it *is* the scheduler's own
+/// defaults), and query failures count as configured too (fail-open), so
+/// callers never block or mislead on a transient D-Bus error.
+fn mode_is_configured(
     scx_loader: &LoaderClientProxyBlocking,
     sched: &SupportedSched,
     mode: SchedMode,
@@ -95,14 +101,17 @@ fn check_mode_configured(
     if mode == SchedMode::Auto {
         return true;
     }
+    scx_loader
+        .scheduler_modes(sched.clone())
+        .map_or(true, |modes| modes.contains(&mode))
+}
 
-    // If the query itself fails, don't block the actual start/switch on it;
-    // just skip the warning and let scx_loader do what it would do anyway.
-    let Ok(configured_modes) = scx_loader.scheduler_modes(sched.clone()) else {
-        return true;
-    };
-
-    let is_configured = configured_modes.contains(&mode);
+fn check_mode_configured(
+    scx_loader: &LoaderClientProxyBlocking,
+    sched: &SupportedSched,
+    mode: SchedMode,
+) -> bool {
+    let is_configured = mode_is_configured(scx_loader, sched, mode);
     if !is_configured {
         eprintln!(
             "{} {sched:?} has no configured arguments for {mode:?} mode; it will run with its own defaults",
@@ -257,7 +266,13 @@ fn cmd_restore(scx_loader: &LoaderClientProxyBlocking) -> Result<(), Box<dyn std
     // Fetch the default mode for display
     let default_mode: SchedMode = scx_loader.default_mode()?;
     let sched = SupportedSched::try_from(default_scheduler.as_str())?;
-    println!("restored default scheduler {sched:?} in {default_mode:?} mode");
+    let mode_configured = mode_is_configured(scx_loader, &sched, default_mode);
+    report_mode_result(
+        "restored default scheduler",
+        &sched,
+        default_mode,
+        mode_configured,
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR refines the recently added scheduler mode handling in `scxctl`.

It improves the accuracy and consistency of user-facing messages, removes duplicated reporting logic, and resolves the current mode lazily during `switch` operations. It also ensures that switching to a different scheduler without an explicit mode uses the target scheduler's `Auto` mode instead of inheriting the previously active mode.

Following the Don't Repeat Yourself principle, the common reporting logic from `cmd_start()` and `cmd_switch()` has been moved into the shared `report_mode_result()` helper. This keeps both commands consistent and reduces the risk of their behaviour diverging in future changes.

Runtime testing covered configured and unconfigured modes, D-Bus service activation, and switching between Bpfland, Flash, and LAVD.
