### PR TITLE
scxtui: preview mode arguments and support session-only custom args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,7 @@ dependencies = [
  "ratatui",
  "scx_loader",
  "serde_json",
+ "shell-words",
  "zbus",
 ]
 

--- a/crates/scxtui/Cargo.toml
+++ b/crates/scxtui/Cargo.toml
@@ -18,6 +18,9 @@ ratatui = "0.30.2"
 scx_loader = { path = "../scx_loader", version="1.1.2" }
 # Mirrors scxctl's dependency spec; the blocking connection lives here.
 zbus = "5.16"
+# Renders argument previews exactly like scxctl renders scheduler
+# arguments (`shell_words::join`), so both clients show the same form.
+shell-words = "1.1"
 # Log view: journalctl --output=json parsing + local-time formatting.
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/crates/scxtui/README.md
+++ b/crates/scxtui/README.md
@@ -43,6 +43,9 @@ unprivileged D-Bus client; scheduler lifecycle management remains in
 - Displays the kernel's own `sched_ext` state from sysfs and warns when it
   disagrees with the backend: schedulers attached outside the backend's
   control, crashed or watchdog-ejected schedulers, and ops-name mismatches.
+- Previews the arguments a selected mode is configured with, rendered in
+  the same shell-words form as `scxctl`, cached per scheduler and refreshed
+  when the daemon restarts.
 - Warns when a selected mode has no configured arguments and scheduler
   defaults will be used.
 - Stops, restarts, or restores the configured default scheduler. A restart

--- a/crates/scxtui/README.md
+++ b/crates/scxtui/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img
-    src="assets/scxtui-logo.png"
+    src="https://raw.githubusercontent.com/sched-ext/scx-loader/main/crates/scxtui/assets/scxtui-logo.png"
     alt="scxtui logo"
     width="320"
   >
@@ -11,10 +11,8 @@
 **A terminal user interface for managing Linux [`sched_ext`](https://github.com/sched-ext/scx) schedulers through [`scx_loader`](https://github.com/sched-ext/scx-loader) or `scx.service`.**
 
 [![Crates.io](https://img.shields.io/crates/v/scxtui.svg)](https://crates.io/crates/scxtui)
-[![License](https://img.shields.io/crates/l/scxtui.svg)](../../LICENSE)
+[![License](https://img.shields.io/crates/l/scxtui.svg)](https://github.com/sched-ext/scx-loader/blob/main/LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Linux-blue.svg)](#requirements)
-
-</div>
 
 `scxtui` provides an interactive view of the available `sched_ext` schedulers.
 It can start and switch schedulers, select operating modes, inspect the

--- a/crates/scxtui/README.md
+++ b/crates/scxtui/README.md
@@ -48,6 +48,10 @@ unprivileged D-Bus client; scheduler lifecycle management remains in
   when the daemon restarts.
 - Warns when a selected mode has no configured arguments and scheduler
   defaults will be used.
+- Starts or switches a scheduler with free-form custom arguments, using the
+  exact `--args` syntax and semantics of `scxctl` (comma split, then
+  shell-style words). The arguments are session-only: nothing is written to
+  the loader configuration.
 - Stops, restarts, or restores the configured default scheduler. A restart
   with a different mode selected for the running scheduler applies that
   mode.
@@ -138,6 +142,7 @@ of leaving the terminal in a broken state.
 | `Tab`, `m` | Select the next mode |
 | `Shift+Tab`, `M` | Select the previous mode |
 | `Enter` | Start the selected scheduler, or switch to it when one is already running |
+| `a` | Open the custom-arguments field; `Enter` starts/switches with the typed arguments (session-only), `Esc` cancels |
 | `s` | Stop the running scheduler |
 | `r` | Restart the running scheduler; applies the selected mode when it differs |
 | `d` | Restore the scheduler and mode configured as default |

--- a/crates/scxtui/src/app.rs
+++ b/crates/scxtui/src/app.rs
@@ -8,10 +8,11 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::DefaultTerminal;
 use scx_loader::SchedMode;
 
+use crate::args::{expand_input, ArgsExpandError};
 use crate::backend::loader::LoaderBackend;
 use crate::backend::service::ServiceBackend;
 use crate::backend::{Capabilities, ModeArgs, SchedulerBackend, Status};
@@ -80,14 +81,60 @@ pub fn make_backend(kind: BackendKind) -> Result<Box<dyn SchedulerBackend>> {
 /// loop right after the frame announcing them has been drawn. Backend
 /// calls block (a hung daemon holds the D-Bus timeout, ~25 s), so the UI
 /// must show feedback *before* making them.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum PendingAction {
     StartOrSwitch,
+    /// Expanded field content; see [`App::submit_args`].
+    StartOrSwitchWithArgs(Vec<String>),
     Stop,
     Restart,
     RestoreDefault,
     ToggleBackend,
     Monitor,
+}
+
+/// State of the session-only custom-arguments field. The cursor is
+/// counted in characters, not bytes, so editing multi-byte input stays
+/// sound; the UI derives its cursor block from the same count.
+#[derive(Default)]
+pub struct ArgsInput {
+    pub buffer: String,
+    pub cursor: usize,
+}
+
+impl ArgsInput {
+    /// Byte offset of the character cursor, for `String` edits.
+    fn byte_cursor(&self) -> usize {
+        self.buffer
+            .char_indices()
+            .nth(self.cursor)
+            .map_or(self.buffer.len(), |(idx, _)| idx)
+    }
+
+    fn len_chars(&self) -> usize {
+        self.buffer.chars().count()
+    }
+
+    fn insert(&mut self, c: char) {
+        let at = self.byte_cursor();
+        self.buffer.insert(at, c);
+        self.cursor += 1;
+    }
+
+    fn backspace(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+            let at = self.byte_cursor();
+            self.buffer.remove(at);
+        }
+    }
+
+    fn delete(&mut self) {
+        let at = self.byte_cursor();
+        if at < self.buffer.len() {
+            self.buffer.remove(at);
+        }
+    }
 }
 
 /// Which screen is currently shown.
@@ -123,6 +170,9 @@ pub struct App {
     /// Last observed backend instance token; a change invalidates
     /// `mode_args`.
     daemon_instance: Option<String>,
+    /// Custom-arguments field; `Some` while the user is typing. While
+    /// open it owns every key press.
+    pub args_input: Option<ArgsInput>,
     pub message: Option<Message>,
     /// Timestamp of the last scheduler-affecting action, for debouncing.
     last_action: Option<Instant>,
@@ -157,6 +207,7 @@ impl App {
             kernel: None,
             mode_args: HashMap::new(),
             daemon_instance: None,
+            args_input: None,
             message: None,
             last_action: None,
             view: View::Schedulers,
@@ -319,6 +370,7 @@ or your distro's scx tools package)",
     fn run_action(&mut self, action: PendingAction, terminal: &mut DefaultTerminal) -> Result<()> {
         match action {
             PendingAction::StartOrSwitch => self.start_or_switch(),
+            PendingAction::StartOrSwitchWithArgs(args) => self.start_or_switch_with_args(&args),
             PendingAction::Stop => self.act("stopped", |b| b.stop()),
             PendingAction::Restart => self.restart_scheduler(),
             PendingAction::RestoreDefault => {
@@ -331,9 +383,70 @@ or your distro's scx tools package)",
     }
 
     fn on_key(&mut self, key: KeyEvent) {
+        if self.view == View::Schedulers && self.args_input.is_some() {
+            self.on_key_args(key);
+            return;
+        }
         match self.view {
             View::Schedulers => self.on_key_schedulers(key),
             View::Logs => self.on_key_logs(key),
+        }
+    }
+
+    /// Key handling while the custom-arguments field is open. The field
+    /// owns every key press: global shortcuts must not fire while the
+    /// user is typing text that may well contain their letters — which
+    /// also means `Esc` closes the field here instead of quitting.
+    fn on_key_args(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => self.args_input = None,
+            KeyCode::Enter => self.submit_args(),
+            code => {
+                let Some(input) = self.args_input.as_mut() else {
+                    return;
+                };
+                match code {
+                    KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        input.insert(c);
+                    }
+                    KeyCode::Backspace => input.backspace(),
+                    KeyCode::Delete => input.delete(),
+                    KeyCode::Left => input.cursor = input.cursor.saturating_sub(1),
+                    KeyCode::Right => input.cursor = (input.cursor + 1).min(input.len_chars()),
+                    KeyCode::Home => input.cursor = 0,
+                    KeyCode::End => input.cursor = input.len_chars(),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// `Enter` in the field: expand exactly like scxctl's `--args`, then
+    /// queue the start/switch. Expansion errors keep the field open with
+    /// the message bar explaining what to fix; only a successfully queued
+    /// action closes it.
+    fn submit_args(&mut self) {
+        let Some(buffer) = self.args_input.as_ref().map(|input| input.buffer.clone()) else {
+            return;
+        };
+        match expand_input(&buffer) {
+            Ok(args) => {
+                if self.action_allowed() {
+                    self.args_input = None;
+                    self.queue(PendingAction::StartOrSwitchWithArgs(args));
+                }
+            }
+            Err(ArgsExpandError::Parse(msg)) => {
+                self.error(&format!(
+                    "invalid arguments: {msg} — quotes must be balanced and cannot span a comma"
+                ));
+            }
+            Err(ArgsExpandError::Empty) => {
+                self.error(
+                    "arguments expanded to nothing — to run with scheduler defaults, \
+press Esc and use Enter instead",
+                );
+            }
         }
     }
 
@@ -353,6 +466,11 @@ or your distro's scx tools package)",
             }
             KeyCode::Down | KeyCode::Char('j') => self.select_next(),
             KeyCode::Up | KeyCode::Char('k') => self.select_prev(),
+            KeyCode::Char('a') if self.backend.capabilities().custom_args => {
+                if self.selected_scheduler().is_some() {
+                    self.args_input = Some(ArgsInput::default());
+                }
+            }
             KeyCode::Tab | KeyCode::Char('m') if self.backend.capabilities().modes => {
                 self.cycle_mode(true);
             }
@@ -622,6 +740,58 @@ or your distro's scx tools package)",
         self.refresh_status();
     }
 
+    /// The with-args sibling of [`Self::start_or_switch`]: the same
+    /// start-vs-switch decision against a re-read daemon state, but the
+    /// scheduler receives the expanded field content instead of a mode.
+    /// The arguments are session-only — the loader keeps them for this
+    /// run and nothing is written to its config — and both the success
+    /// notice and a failure render them in the same shell-words form the
+    /// status panel and scxctl use.
+    fn start_or_switch_with_args(&mut self, args: &[String]) {
+        let Some(sched) = self.selected_scheduler().map(str::to_owned) else {
+            return;
+        };
+        // Same staleness concern as in `start_or_switch`.
+        self.refresh_status();
+        let running = self
+            .status
+            .as_ref()
+            .and_then(|status| status.current.clone());
+
+        let result = if running.is_some() {
+            self.backend.switch_with_args(&sched, args)
+        } else {
+            self.backend.start_with_args(&sched, args)
+        };
+
+        let rendered = shell_words::join(args);
+        match result {
+            Ok(()) => {
+                let verb = if running.is_none() {
+                    "started"
+                } else if running.as_deref() == Some(sched.as_str()) {
+                    "restarted"
+                } else {
+                    "switched to"
+                };
+                self.info(&format!(
+                    "{verb} {sched} with args: {rendered} (session-only)"
+                ));
+            }
+            Err(err) => {
+                let verb = if running.is_some() {
+                    "switch to"
+                } else {
+                    "start"
+                };
+                self.error(&format!(
+                    "{verb} {sched} with args '{rendered}' failed: {err:#}"
+                ));
+            }
+        }
+        self.refresh_status();
+    }
+
     /// `r`: restart. Plain `RestartScheduler` deliberately reuses the
     /// original configuration, so by itself it can never apply a mode
     /// change — and the very first piece of community feedback was someone
@@ -815,6 +985,7 @@ mod tests {
             Capabilities {
                 live_switch: true,
                 modes: true,
+                custom_args: true,
                 restore_default: true,
             }
         }
@@ -844,6 +1015,12 @@ mod tests {
             Ok(())
         }
         fn switch(&self, _sched: &str, _mode: SchedMode) -> Result<()> {
+            Ok(())
+        }
+        fn start_with_args(&self, _sched: &str, _args: &[String]) -> Result<()> {
+            Ok(())
+        }
+        fn switch_with_args(&self, _sched: &str, _args: &[String]) -> Result<()> {
             Ok(())
         }
         fn stop(&self) -> Result<()> {
@@ -1018,6 +1195,95 @@ mod tests {
             *queries.borrow(),
             2,
             "R must refetch instead of serving the cache"
+        );
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::from(code)
+    }
+
+    fn type_str(app: &mut App, text: &str) {
+        for c in text.chars() {
+            app.on_key(key(KeyCode::Char(c)));
+        }
+    }
+
+    #[test]
+    fn args_field_opens_on_a_and_owns_global_keys() {
+        let mut app = app_with_backend(StubBackend::new());
+        app.on_key(key(KeyCode::Char('a')));
+        assert!(app.args_input.is_some());
+
+        // 'q' quits globally, but inside the field it is just a letter.
+        app.on_key(key(KeyCode::Char('q')));
+        assert!(!app.should_quit);
+        assert_eq!(app.args_input.as_ref().unwrap().buffer, "q");
+
+        // Esc closes the field instead of quitting the app.
+        app.on_key(key(KeyCode::Esc));
+        assert!(app.args_input.is_none());
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn args_field_edits_at_the_character_cursor() {
+        let mut app = app_with_backend(StubBackend::new());
+        app.on_key(key(KeyCode::Char('a')));
+        type_str(&mut app, "ad");
+        app.on_key(key(KeyCode::Left));
+        type_str(&mut app, "bc");
+        app.on_key(key(KeyCode::End));
+        app.on_key(key(KeyCode::Backspace));
+        assert_eq!(app.args_input.as_ref().unwrap().buffer, "abc");
+
+        // Multi-byte characters: the cursor counts characters, not bytes.
+        app.on_key(key(KeyCode::Home));
+        type_str(&mut app, "żó");
+        app.on_key(key(KeyCode::Home));
+        app.on_key(key(KeyCode::Delete));
+        assert_eq!(app.args_input.as_ref().unwrap().buffer, "óabc");
+    }
+
+    #[test]
+    fn args_parse_error_keeps_the_field_open() {
+        let mut app = app_with_backend(StubBackend::new());
+        app.on_key(key(KeyCode::Char('a')));
+        type_str(&mut app, "--name \"foo");
+        app.on_key(key(KeyCode::Enter));
+
+        assert!(app.args_input.is_some(), "the user must be able to fix it");
+        assert!(app.message.as_ref().unwrap().is_error);
+        assert!(app.pending_action.is_none());
+    }
+
+    #[test]
+    fn args_empty_input_is_rejected() {
+        let mut app = app_with_backend(StubBackend::new());
+        app.on_key(key(KeyCode::Char('a')));
+        type_str(&mut app, "   ");
+        app.on_key(key(KeyCode::Enter));
+
+        assert!(app.args_input.is_some());
+        assert!(app.message.as_ref().unwrap().is_error);
+        assert!(app.pending_action.is_none());
+    }
+
+    #[test]
+    fn args_valid_input_queues_the_expanded_action() {
+        let mut app = app_with_backend(StubBackend::new());
+        app.on_key(key(KeyCode::Char('a')));
+        type_str(&mut app, "-s 20000,-m powersave");
+        app.on_key(key(KeyCode::Enter));
+
+        assert!(app.args_input.is_none(), "a queued action closes the field");
+        let Some(PendingAction::StartOrSwitchWithArgs(args)) = &app.pending_action else {
+            panic!("expected a queued with-args action");
+        };
+        assert_eq!(
+            args,
+            &["-s", "20000", "-m", "powersave"]
+                .map(str::to_string)
+                .to_vec()
         );
     }
 

--- a/crates/scxtui/src/app.rs
+++ b/crates/scxtui/src/app.rs
@@ -2,6 +2,7 @@
 
 //! Application state and event loop.
 
+use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -30,17 +31,6 @@ pub const MODES: [SchedMode; 5] = [
 /// Lower-case mode name, matching the status panel and scxctl's CLI.
 fn mode_label(mode: SchedMode) -> &'static str {
     <&str>::from(mode)
-}
-
-/// Filters a [`ModeArgs`] answer down to the modes that count as
-/// configured: `Auto` always, anything else when its resolved argument
-/// list is non-empty.
-fn derive_configured(modes: ModeArgs) -> Vec<SchedMode> {
-    modes
-        .into_iter()
-        .filter(|(mode, args)| *mode == SchedMode::Auto || !args.is_empty())
-        .map(|(mode, _)| mode)
-        .collect()
 }
 
 /// How often the input poll wakes up to redraw / refresh.
@@ -124,8 +114,15 @@ pub struct App {
     /// The kernel's own view of `sched_ext`, refreshed alongside `status`.
     /// `None` = kernel without `sched_ext` support.
     pub kernel: Option<KernelState>,
-    /// Configured modes for the currently selected scheduler.
-    pub configured_modes: Vec<SchedMode>,
+    /// Lazily filled per-scheduler answers to the backend's mode-argument
+    /// query. An absent key means "not fetched yet or the query failed" —
+    /// never "nothing configured" — so consumers fail open on it. Valid
+    /// for the lifetime of one daemon instance; see
+    /// [`Self::check_daemon_instance`].
+    mode_args: HashMap<String, ModeArgs>,
+    /// Last observed backend instance token; a change invalidates
+    /// `mode_args`.
+    daemon_instance: Option<String>,
     pub message: Option<Message>,
     /// Timestamp of the last scheduler-affecting action, for debouncing.
     last_action: Option<Instant>,
@@ -158,7 +155,8 @@ impl App {
             mode_idx: 0,
             status: None,
             kernel: None,
-            configured_modes: Vec::new(),
+            mode_args: HashMap::new(),
+            daemon_instance: None,
             message: None,
             last_action: None,
             view: View::Schedulers,
@@ -193,14 +191,24 @@ impl App {
     }
 
     /// Whether the selected mode has configured arguments for the selected
-    /// scheduler. Mirrors scxctl's client-side warning: `Auto` always counts,
-    /// and an earlier query failure fails open (empty list is treated as
-    /// "unknown", not as "nothing configured") so we never scare the user
-    /// over a transient D-Bus hiccup.
+    /// scheduler. Mirrors scxctl's client-side warning: `Auto` always
+    /// counts, and an unknown answer (never fetched, or the query failed —
+    /// either way no cache entry) fails open so we never scare the user
+    /// over a transient D-Bus hiccup. A *successful* answer is exact: the
+    /// daemon reports every mode, so a mode missing its arguments there
+    /// genuinely has none configured.
     pub fn selected_mode_configured(&self) -> bool {
-        self.selected_mode() == SchedMode::Auto
-            || self.configured_modes.is_empty()
-            || self.configured_modes.contains(&self.selected_mode())
+        let mode = self.selected_mode();
+        if mode == SchedMode::Auto {
+            return true;
+        }
+        let Some(modes) = self
+            .selected_scheduler()
+            .and_then(|sched| self.mode_args.get(sched))
+        else {
+            return true;
+        };
+        modes.iter().any(|(m, args)| *m == mode && !args.is_empty())
     }
 
     pub fn run(&mut self, mut terminal: DefaultTerminal) -> Result<()> {
@@ -363,6 +371,9 @@ or your distro's scx tools package)",
                 // same rule as refresh_status not touching the message bar.
                 let list_ok = self.refresh_schedulers();
                 self.refresh_status();
+                // Manual refresh means "give me the current truth", so the
+                // lazy cache must not satisfy it with old answers.
+                self.mode_args.clear();
                 self.refresh_modes();
                 if list_ok {
                     self.info("refreshed");
@@ -413,6 +424,11 @@ or your distro's scx tools package)",
                 self.schedulers = schedulers;
                 self.selected = 0;
                 self.mode_idx = 0;
+                // Instance tokens are per-backend; comparing across
+                // backends would be meaningless, so both the cache and the
+                // observed token start over.
+                self.mode_args.clear();
+                self.daemon_instance = None;
                 self.refresh_status();
                 self.sync_selection_to_running();
                 self.refresh_modes();
@@ -652,6 +668,7 @@ or your distro's scx tools package)",
     fn refresh_status(&mut self) {
         self.status = self.backend.status().ok();
         self.kernel = kernel::read();
+        self.check_daemon_instance();
     }
 
     /// Re-enumerates the scheduler list. The list is otherwise fetched
@@ -676,25 +693,50 @@ or your distro's scx tools package)",
         }
     }
 
-    /// Configured modes are derived from the full per-mode argument query
-    /// (`SchedulerModeArgs`): `Auto` always counts, any other mode counts
-    /// when its resolved argument list is non-empty — the same rule the
-    /// daemon applies in `SchedulerModes`. Deriving locally lets a single
-    /// query serve both this indicator and an argument preview without a
-    /// second source of truth.
+    /// Lazily fills the per-scheduler argument cache. The daemon reads its
+    /// configuration once at startup, so a successful answer stays valid
+    /// until the daemon itself is replaced — which `check_daemon_instance`
+    /// watches for. A failed query is deliberately *not* cached: an absent
+    /// entry reads as "unknown" (fail open in `selected_mode_configured`)
+    /// and the next call here simply retries.
     fn refresh_modes(&mut self) {
-        self.configured_modes = match self.selected_scheduler() {
-            Some(sched) if self.backend.capabilities().modes => {
-                // Fail open: a successful answer always contains at least
-                // `Auto`, so an empty list still means "unknown" to
-                // `selected_mode_configured`, not "nothing configured".
-                self.backend
-                    .mode_args(sched)
-                    .map(derive_configured)
-                    .unwrap_or_default()
-            }
-            _ => Vec::new(),
+        if !self.backend.capabilities().modes {
+            return;
+        }
+        let Some(sched) = self.selected_scheduler() else {
+            return;
         };
+        if self.mode_args.contains_key(sched) {
+            return;
+        }
+        let sched = sched.to_owned();
+        if let Ok(modes) = self.backend.mode_args(&sched) {
+            self.mode_args.insert(sched, modes);
+        }
+    }
+
+    /// Detects a daemon restart via the backend's instance token and drops
+    /// the mode-argument cache when one happened. A replaced daemon is the
+    /// one event that can make cached configuration answers stale (the
+    /// daemon reads its config once at startup) — watching the config
+    /// file's mtime instead would be both weaker (an edit without a
+    /// restart changes nothing) and blind to a restart with an unchanged
+    /// file. Rides along the periodic status refresh, so an external
+    /// `systemctl restart scx_loader` is picked up within one poll even
+    /// though D-Bus activation hides it from the calls themselves.
+    fn check_daemon_instance(&mut self) {
+        let Some(token) = self.backend.instance_token() else {
+            return;
+        };
+        if self
+            .daemon_instance
+            .as_deref()
+            .is_some_and(|old| old != token)
+        {
+            self.mode_args.clear();
+            self.refresh_modes();
+        }
+        self.daemon_instance = Some(token);
     }
 
     fn info(&mut self, text: &str) {
@@ -716,17 +758,45 @@ or your distro's scx tools package)",
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use anyhow::anyhow;
+
     use super::*;
 
-    /// Minimal in-memory backend: enough for exercising selection logic
-    /// without a D-Bus connection.
+    /// Minimal in-memory backend: enough for exercising selection and
+    /// caching logic without a D-Bus connection.
     struct StubBackend {
         schedulers: Vec<String>,
+        /// Per-scheduler answer for `mode_args`; a missing key errors,
+        /// modeling a failed D-Bus query.
+        modes: HashMap<String, ModeArgs>,
+        /// How many times `mode_args` reached the backend, shared with the
+        /// test so caching is observable from the outside.
+        mode_queries: Rc<RefCell<usize>>,
+        /// Current instance token, shared so a test can "restart" the
+        /// daemon underneath the app.
+        token: Rc<RefCell<Option<String>>>,
+    }
+
+    impl StubBackend {
+        fn new() -> Self {
+            Self {
+                schedulers: vec!["scx_bpfland".into(), "scx_lavd".into(), "scx_cake".into()],
+                modes: HashMap::new(),
+                mode_queries: Rc::new(RefCell::new(0)),
+                token: Rc::new(RefCell::new(None)),
+            }
+        }
     }
 
     impl SchedulerBackend for StubBackend {
         fn label(&self) -> &'static str {
             "stub"
+        }
+        fn instance_token(&self) -> Option<String> {
+            self.token.borrow().clone()
         }
         fn capabilities(&self) -> Capabilities {
             Capabilities {
@@ -736,13 +806,26 @@ mod tests {
             }
         }
         fn status(&self) -> Result<Status> {
-            unreachable!("tests set App::status directly")
+            // Benign "nothing running" answer, so tests may drive paths
+            // that refresh the status; tests interested in a particular
+            // state still set `App::status` directly afterwards.
+            Ok(Status {
+                current: None,
+                mode: SchedMode::Auto,
+                args: Vec::new(),
+                default_sched: None,
+                default_mode: SchedMode::Auto,
+            })
         }
         fn supported_schedulers(&self) -> Result<Vec<String>> {
             Ok(self.schedulers.clone())
         }
-        fn mode_args(&self, _sched: &str) -> Result<ModeArgs> {
-            Ok(Vec::new())
+        fn mode_args(&self, sched: &str) -> Result<ModeArgs> {
+            *self.mode_queries.borrow_mut() += 1;
+            self.modes
+                .get(sched)
+                .cloned()
+                .ok_or_else(|| anyhow!("no mode answer configured for {sched}"))
         }
         fn start(&self, _sched: &str, _mode: SchedMode) -> Result<()> {
             Ok(())
@@ -761,13 +844,31 @@ mod tests {
         }
     }
 
+    /// Answer for the default selection (`scx_bpfland`): gaming has
+    /// arguments, powersave is present but empty, the rest untouched.
+    fn bpfland_modes() -> ModeArgs {
+        vec![
+            (SchedMode::Auto, Vec::new()),
+            (
+                SchedMode::Gaming,
+                vec!["-k".into(), "-s".into(), "5000".into()],
+            ),
+            (SchedMode::PowerSave, Vec::new()),
+        ]
+    }
+
+    fn app_with_backend(backend: StubBackend) -> App {
+        App::new(BackendKind::Loader, Box::new(backend)).unwrap()
+    }
+
     fn app_with_status(status: Status) -> App {
-        let backend = StubBackend {
-            schedulers: vec!["scx_bpfland".into(), "scx_lavd".into(), "scx_cake".into()],
-        };
-        let mut app = App::new(BackendKind::Loader, Box::new(backend)).unwrap();
+        let mut app = app_with_backend(StubBackend::new());
         app.status = Some(status);
         app
+    }
+
+    fn select_mode(app: &mut App, mode: SchedMode) {
+        app.mode_idx = MODES.iter().position(|m| *m == mode).unwrap();
     }
 
     fn running(current: &str, mode: SchedMode, args: &[&str]) -> Status {
@@ -778,6 +879,109 @@ mod tests {
             default_sched: None,
             default_mode: SchedMode::Auto,
         }
+    }
+
+    #[test]
+    fn configured_follows_the_cached_argument_lists() {
+        let mut backend = StubBackend::new();
+        backend.modes.insert("scx_bpfland".into(), bpfland_modes());
+        let mut app = app_with_backend(backend);
+        app.refresh_modes();
+
+        select_mode(&mut app, SchedMode::Auto);
+        assert!(app.selected_mode_configured(), "Auto always counts");
+        select_mode(&mut app, SchedMode::Gaming);
+        assert!(app.selected_mode_configured(), "non-empty arguments");
+        select_mode(&mut app, SchedMode::PowerSave);
+        assert!(
+            !app.selected_mode_configured(),
+            "present in the answer with an empty argument list"
+        );
+        select_mode(&mut app, SchedMode::Server);
+        assert!(
+            !app.selected_mode_configured(),
+            "absent from a successful answer means not configured"
+        );
+    }
+
+    #[test]
+    fn unknown_answer_fails_open() {
+        // No cache entry — the query failed and nothing was stored. Every
+        // mode must count as configured so a transient D-Bus hiccup never
+        // produces a scary warning.
+        let mut app = app_with_backend(StubBackend::new());
+        select_mode(&mut app, SchedMode::Server);
+        assert!(app.selected_mode_configured());
+    }
+
+    #[test]
+    fn cache_serves_repeat_queries() {
+        let mut backend = StubBackend::new();
+        backend.modes.insert("scx_bpfland".into(), bpfland_modes());
+        let queries = Rc::clone(&backend.mode_queries);
+        let mut app = app_with_backend(backend);
+
+        app.refresh_modes();
+        app.refresh_modes();
+        assert_eq!(*queries.borrow(), 1, "second call must hit the cache");
+    }
+
+    #[test]
+    fn failed_query_is_not_cached() {
+        // The stub has no answer for any scheduler, so every query fails.
+        let backend = StubBackend::new();
+        let queries = Rc::clone(&backend.mode_queries);
+        let mut app = app_with_backend(backend);
+
+        app.refresh_modes();
+        app.refresh_modes();
+        assert_eq!(
+            *queries.borrow(),
+            2,
+            "a failure must stay uncached so the next call retries"
+        );
+    }
+
+    #[test]
+    fn daemon_restart_clears_the_cache() {
+        let mut backend = StubBackend::new();
+        backend.modes.insert("scx_bpfland".into(), bpfland_modes());
+        let queries = Rc::clone(&backend.mode_queries);
+        let token = Rc::clone(&backend.token);
+        let mut app = app_with_backend(backend);
+
+        *token.borrow_mut() = Some(":1.7".into());
+        app.check_daemon_instance();
+        app.refresh_modes();
+        assert_eq!(*queries.borrow(), 1);
+
+        // Same daemon: the periodic check must not disturb the cache.
+        app.check_daemon_instance();
+        app.refresh_modes();
+        assert_eq!(*queries.borrow(), 1);
+
+        // "Restart" the daemon: new unique name, cache dropped and the
+        // selected scheduler refetched immediately.
+        *token.borrow_mut() = Some(":1.9".into());
+        app.check_daemon_instance();
+        assert_eq!(*queries.borrow(), 2);
+    }
+
+    #[test]
+    fn manual_refresh_bypasses_the_cache() {
+        let mut backend = StubBackend::new();
+        backend.modes.insert("scx_bpfland".into(), bpfland_modes());
+        let queries = Rc::clone(&backend.mode_queries);
+        let mut app = app_with_backend(backend);
+
+        app.refresh_modes();
+        assert_eq!(*queries.borrow(), 1);
+        app.on_key(KeyEvent::from(KeyCode::Char('R')));
+        assert_eq!(
+            *queries.borrow(),
+            2,
+            "R must refetch instead of serving the cache"
+        );
     }
 
     #[test]

--- a/crates/scxtui/src/app.rs
+++ b/crates/scxtui/src/app.rs
@@ -190,6 +190,19 @@ impl App {
         MODES[self.mode_idx]
     }
 
+    /// Resolved arguments for the selected scheduler and mode, when
+    /// known. `None` covers "not fetched / query failed" as well as a mode
+    /// the daemon did not report; the preview only renders a known,
+    /// non-empty list, so both collapse into "nothing to show".
+    pub fn selected_mode_args(&self) -> Option<&[String]> {
+        let modes = self.mode_args.get(self.selected_scheduler()?)?;
+        let mode = self.selected_mode();
+        modes
+            .iter()
+            .find(|(m, _)| *m == mode)
+            .map(|(_, args)| args.as_slice())
+    }
+
     /// Whether the selected mode has configured arguments for the selected
     /// scheduler. Mirrors scxctl's client-side warning: `Auto` always
     /// counts, and an unknown answer (never fetched, or the query failed —
@@ -912,6 +925,30 @@ mod tests {
         let mut app = app_with_backend(StubBackend::new());
         select_mode(&mut app, SchedMode::Server);
         assert!(app.selected_mode_configured());
+    }
+
+    #[test]
+    fn selected_mode_args_follows_the_selection() {
+        let mut backend = StubBackend::new();
+        backend.modes.insert("scx_bpfland".into(), bpfland_modes());
+        let mut app = app_with_backend(backend);
+        app.refresh_modes();
+
+        select_mode(&mut app, SchedMode::Gaming);
+        let expected = ["-k", "-s", "5000"].map(str::to_string);
+        assert_eq!(app.selected_mode_args(), Some(&expected[..]));
+
+        select_mode(&mut app, SchedMode::Server);
+        assert_eq!(
+            app.selected_mode_args(),
+            None,
+            "a mode absent from the answer has nothing to preview"
+        );
+
+        // scx_lavd has no cache entry at all: same outcome, for the
+        // "unknown" reason.
+        app.selected = 1;
+        assert_eq!(app.selected_mode_args(), None);
     }
 
     #[test]

--- a/crates/scxtui/src/app.rs
+++ b/crates/scxtui/src/app.rs
@@ -13,7 +13,7 @@ use scx_loader::SchedMode;
 
 use crate::backend::loader::LoaderBackend;
 use crate::backend::service::ServiceBackend;
-use crate::backend::{Capabilities, SchedulerBackend, Status};
+use crate::backend::{Capabilities, ModeArgs, SchedulerBackend, Status};
 use crate::kernel::{self, KernelState};
 use crate::logs::{self, LogLine};
 use crate::ui;
@@ -30,6 +30,17 @@ pub const MODES: [SchedMode; 5] = [
 /// Lower-case mode name, matching the status panel and scxctl's CLI.
 fn mode_label(mode: SchedMode) -> &'static str {
     <&str>::from(mode)
+}
+
+/// Filters a [`ModeArgs`] answer down to the modes that count as
+/// configured: `Auto` always, anything else when its resolved argument
+/// list is non-empty.
+fn derive_configured(modes: ModeArgs) -> Vec<SchedMode> {
+    modes
+        .into_iter()
+        .filter(|(mode, args)| *mode == SchedMode::Auto || !args.is_empty())
+        .map(|(mode, _)| mode)
+        .collect()
 }
 
 /// How often the input poll wakes up to redraw / refresh.
@@ -665,12 +676,22 @@ or your distro's scx tools package)",
         }
     }
 
+    /// Configured modes are derived from the full per-mode argument query
+    /// (`SchedulerModeArgs`): `Auto` always counts, any other mode counts
+    /// when its resolved argument list is non-empty — the same rule the
+    /// daemon applies in `SchedulerModes`. Deriving locally lets a single
+    /// query serve both this indicator and an argument preview without a
+    /// second source of truth.
     fn refresh_modes(&mut self) {
         self.configured_modes = match self.selected_scheduler() {
             Some(sched) if self.backend.capabilities().modes => {
-                // Fail open: an empty list means "unknown" to
+                // Fail open: a successful answer always contains at least
+                // `Auto`, so an empty list still means "unknown" to
                 // `selected_mode_configured`, not "nothing configured".
-                self.backend.configured_modes(sched).unwrap_or_default()
+                self.backend
+                    .mode_args(sched)
+                    .map(derive_configured)
+                    .unwrap_or_default()
             }
             _ => Vec::new(),
         };
@@ -720,7 +741,7 @@ mod tests {
         fn supported_schedulers(&self) -> Result<Vec<String>> {
             Ok(self.schedulers.clone())
         }
-        fn configured_modes(&self, _sched: &str) -> Result<Vec<SchedMode>> {
+        fn mode_args(&self, _sched: &str) -> Result<ModeArgs> {
             Ok(Vec::new())
         }
         fn start(&self, _sched: &str, _mode: SchedMode) -> Result<()> {

--- a/crates/scxtui/src/args.rs
+++ b/crates/scxtui/src/args.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Custom scheduler-argument expansion.
+//!
+//! Deliberately reproduces scxctl's `--args` pipeline end to end, so a
+//! string typed into the TUI field means exactly what the same string
+//! means on the scxctl command line: the raw input is first split on
+//! commas (mirroring clap's `value_delimiter(',')`, kept for the
+//! historical comma-separated format), each chunk is then shell-split
+//! via `shell-words`, and the results are flattened in order.
+//!
+//! There is deliberately no shared helper crate between the two clients;
+//! the semantics are pinned instead by a test vector copied verbatim in
+//! both directions (see the note on the shared tables below).
+
+/// Why the field input failed to expand into scheduler arguments.
+/// Mirrors scxctl's `ArgsExpandError`.
+#[derive(Debug, PartialEq)]
+pub enum ArgsExpandError {
+    /// A chunk failed shell-style parsing, e.g. an unclosed quote. This
+    /// also covers quotes that span a comma: the comma split happens
+    /// before quoting is interpreted, so each side of the comma arrives
+    /// here as its own unbalanced chunk. The payload is a display-ready
+    /// message.
+    Parse(String),
+    /// The input expanded to zero arguments (e.g. whitespace only).
+    /// Passing an empty argument list to `StartSchedulerWithArgs` would
+    /// silently mean something other than what the user typed, so the
+    /// client rejects it instead of forwarding it to the daemon.
+    Empty,
+}
+
+/// Expands the raw field input into the final argument list passed to
+/// `scx_loader`: comma split first (clap-compatible), then shell-split
+/// per chunk, flattened — scxctl's pipeline, reproduced 1:1.
+pub fn expand_input(input: &str) -> Result<Vec<String>, ArgsExpandError> {
+    let chunks: Vec<String> = input.split(',').map(str::to_owned).collect();
+    expand_scheduler_args(&chunks)
+}
+
+/// The chunk expansion itself, identical to scxctl's
+/// `expand_scheduler_args`; kept as a separate function so the shared
+/// test vector (whose inputs are pre-split chunks) applies verbatim.
+fn expand_scheduler_args(raw: &[String]) -> Result<Vec<String>, ArgsExpandError> {
+    let mut expanded = Vec::new();
+    for chunk in raw {
+        let tokens = shell_words::split(chunk)
+            .map_err(|err| ArgsExpandError::Parse(format!("{err} in '{chunk}'")))?;
+        expanded.extend(tokens);
+    }
+    if expanded.is_empty() {
+        return Err(ArgsExpandError::Empty);
+    }
+    Ok(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /*
+     * Shared semantics vector, copied verbatim from scxctl's
+     * `args_expansion_shared_vector_ok` / `_errors`. Both clients must
+     * agree on these outcomes; there is deliberately no shared helper
+     * crate. When touching this table, copy it verbatim into the scxctl
+     * tests (and vice versa).
+     *
+     * Inputs are the chunks as produced by clap's value_delimiter(','),
+     * i.e. already comma-split.
+     */
+    #[test]
+    fn args_expansion_shared_vector_ok() {
+        let cases: &[(&[&str], &[&str])] = &[
+            // Comma style (the historical documented format): still supported.
+            (&["--slice-us", "5000"], &["--slice-us", "5000"]),
+            // Whitespace inside a single chunk now separates arguments.
+            (
+                &["--verbose --slice-us 5000"],
+                &["--verbose", "--slice-us", "5000"],
+            ),
+            // Mixed: comma split first (clap), then shell split per chunk.
+            (
+                &["--verbose", "--slice-us 5000"],
+                &["--verbose", "--slice-us", "5000"],
+            ),
+            // Double quotes are interpreted: value with a space stays one token.
+            (&["--name \"foo bar\""], &["--name", "foo bar"]),
+            // Single quotes likewise.
+            (&["--name 'foo bar'"], &["--name", "foo bar"]),
+            // Backslash escapes a space.
+            (&["--path /tmp/a\\ b"], &["--path", "/tmp/a b"]),
+            // An explicit empty token is explicit: passed through as-is.
+            (&["\"\""], &[""]),
+            // Empty values remain visible when attached to another option.
+            (&["--name \"\""], &["--name", ""]),
+        ];
+        for (input, expected) in cases {
+            let input: Vec<String> = input.iter().map(ToString::to_string).collect();
+            let expected: Vec<String> = expected.iter().map(ToString::to_string).collect();
+            assert_eq!(
+                expand_scheduler_args(&input),
+                Ok(expected),
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn args_expansion_shared_vector_errors() {
+        // An unclosed quote in a chunk is a parse error.
+        let unclosed = vec!["--name \"foo".to_string()];
+        assert!(matches!(
+            expand_scheduler_args(&unclosed),
+            Err(ArgsExpandError::Parse(_))
+        ));
+
+        // A quoted region spanning a comma cannot survive clap's earlier
+        // comma split: each side arrives as an unbalanced chunk. Surfacing
+        // a parse error here (instead of silently mangled tokens) is the
+        // intended behavior.
+        let quote_spanning_comma = vec!["\"foo".to_string(), "bar\"".to_string()];
+        assert!(matches!(
+            expand_scheduler_args(&quote_spanning_comma),
+            Err(ArgsExpandError::Parse(_))
+        ));
+
+        // Whitespace-only input expands to nothing: rejected client-side
+        // instead of sending an empty list to the daemon.
+        let blank = vec!["   ".to_string()];
+        assert_eq!(expand_scheduler_args(&blank), Err(ArgsExpandError::Empty));
+
+        // clap turns `--args ""` into a single empty chunk; same outcome.
+        let empty_chunk = vec![String::new()];
+        assert_eq!(
+            expand_scheduler_args(&empty_chunk),
+            Err(ArgsExpandError::Empty)
+        );
+    }
+
+    /// Full-pipeline checks on top of the shared vector: the exact string
+    /// a user would pass to `scxctl --args=...` typed into the field
+    /// yields the same final tokens, comma split included.
+    #[test]
+    fn field_input_matches_the_scxctl_pipeline() {
+        assert_eq!(
+            expand_input("-s 20000,-m powersave,-I 100,-t 100"),
+            Ok(["-s", "20000", "-m", "powersave", "-I", "100", "-t", "100"]
+                .map(str::to_string)
+                .to_vec())
+        );
+        assert_eq!(
+            expand_input("--verbose --slice-us 5000"),
+            Ok(["--verbose", "--slice-us", "5000"]
+                .map(str::to_string)
+                .to_vec())
+        );
+        // A quoted region spanning a comma: parse error, as on the CLI.
+        assert!(matches!(
+            expand_input("--name \"foo,bar\""),
+            Err(ArgsExpandError::Parse(_))
+        ));
+        // Whitespace-only and empty input: rejected client-side.
+        assert_eq!(expand_input("   "), Err(ArgsExpandError::Empty));
+        assert_eq!(expand_input(""), Err(ArgsExpandError::Empty));
+    }
+}

--- a/crates/scxtui/src/backend/loader.rs
+++ b/crates/scxtui/src/backend/loader.rs
@@ -51,6 +51,10 @@ trait Loader {
 
     fn switch_scheduler(&self, scx_name: &str, sched_mode: SchedMode) -> zbus::Result<()>;
 
+    fn start_scheduler_with_args(&self, scx_name: &str, scx_args: &[String]) -> zbus::Result<()>;
+
+    fn switch_scheduler_with_args(&self, scx_name: &str, scx_args: &[String]) -> zbus::Result<()>;
+
     fn stop_scheduler(&self) -> zbus::Result<()>;
 
     fn restart_scheduler(&self) -> zbus::Result<()>;
@@ -199,6 +203,7 @@ impl SchedulerBackend for LoaderBackend {
         Capabilities {
             live_switch: true,
             modes: true,
+            custom_args: true,
             restore_default: true,
         }
     }
@@ -254,6 +259,14 @@ impl SchedulerBackend for LoaderBackend {
 
     fn switch(&self, sched: &str, mode: SchedMode) -> Result<()> {
         Ok(self.proxy.switch_scheduler(sched, mode)?)
+    }
+
+    fn start_with_args(&self, sched: &str, args: &[String]) -> Result<()> {
+        Ok(self.proxy.start_scheduler_with_args(sched, args)?)
+    }
+
+    fn switch_with_args(&self, sched: &str, args: &[String]) -> Result<()> {
+        Ok(self.proxy.switch_scheduler_with_args(sched, args)?)
     }
 
     fn stop(&self) -> Result<()> {

--- a/crates/scxtui/src/backend/loader.rs
+++ b/crates/scxtui/src/backend/loader.rs
@@ -82,6 +82,10 @@ pub struct LoaderBackend {
     // The generated proxy holds its own reference to the connection,
     // so we don't need to keep the `Connection` around separately.
     proxy: LoaderProxyBlocking<'static>,
+    /// `org.freedesktop.DBus` proxy, kept for `GetNameOwner`: the unique
+    /// name of the current `org.scx.Loader` owner is the instance token
+    /// (see [`SchedulerBackend::instance_token`]).
+    dbus: DBusProxy<'static>,
     /// `org.freedesktop.DBus.Properties` proxy for the same object, used to
     /// fetch the whole status in a single `GetAll` round-trip instead of
     /// five per-property `Get`s (see [`SchedulerBackend::status`]).
@@ -158,6 +162,7 @@ is the scx_loader service installed?"
         Ok(Self {
             proxy,
             props,
+            dbus,
             initial_schedulers: RefCell::new(Some(schedulers)),
         })
     }
@@ -196,6 +201,18 @@ impl SchedulerBackend for LoaderBackend {
             modes: true,
             restore_default: true,
         }
+    }
+
+    /// One cheap round-trip to the bus daemon itself (not to `scx_loader`),
+    /// so it can ride along the periodic status refresh. A momentarily
+    /// unowned name maps to `None` — the caller keeps its caches and a
+    /// later successful read reports the (new) owner.
+    fn instance_token(&self) -> Option<String> {
+        let name = BusName::from_static_str(SERVICE).expect("valid bus name literal");
+        self.dbus
+            .get_name_owner(name)
+            .ok()
+            .map(|owner| owner.to_string())
     }
 
     /// One `GetAll` round-trip instead of five `Get`s. With property

--- a/crates/scxtui/src/backend/loader.rs
+++ b/crates/scxtui/src/backend/loader.rs
@@ -30,7 +30,7 @@ use zbus::names::{BusName, InterfaceName};
 use zbus::proxy::CacheProperties;
 use zbus::zvariant::OwnedValue;
 
-use super::{Capabilities, SchedulerBackend, Status};
+use super::{Capabilities, ModeArgs, SchedulerBackend, Status};
 
 /// Sentinel used by `scx_loader` for "nothing running / not configured".
 const UNKNOWN: &str = "unknown";
@@ -57,7 +57,7 @@ trait Loader {
 
     fn restore_default(&self) -> zbus::Result<()>;
 
-    fn scheduler_modes(&self, scx_name: &str) -> zbus::Result<Vec<SchedMode>>;
+    fn scheduler_mode_args(&self, scx_name: &str) -> zbus::Result<ModeArgs>;
 
     #[zbus(property)]
     fn current_scheduler(&self) -> zbus::Result<String>;
@@ -227,8 +227,8 @@ impl SchedulerBackend for LoaderBackend {
         Ok(self.proxy.supported_schedulers()?)
     }
 
-    fn configured_modes(&self, sched: &str) -> Result<Vec<SchedMode>> {
-        Ok(self.proxy.scheduler_modes(sched)?)
+    fn mode_args(&self, sched: &str) -> Result<ModeArgs> {
+        Ok(self.proxy.scheduler_mode_args(sched)?)
     }
 
     fn start(&self, sched: &str, mode: SchedMode) -> Result<()> {

--- a/crates/scxtui/src/backend/mod.rs
+++ b/crates/scxtui/src/backend/mod.rs
@@ -58,6 +58,18 @@ pub trait SchedulerBackend {
     /// Short human-readable backend name for the status bar.
     fn label(&self) -> &'static str;
 
+    /// Opaque token identifying the live backend instance behind this
+    /// connection — for the loader, the unique bus name of the current
+    /// `org.scx.Loader` owner. The daemon reads its configuration once at
+    /// startup, so client-side caches of configuration answers stay valid
+    /// exactly as long as the token does: a changed token is a replaced
+    /// daemon. `None` means the backend has no such notion, or the owner
+    /// is momentarily unknown; callers should keep their caches on `None`
+    /// rather than dropping known-good data over a transient hiccup.
+    fn instance_token(&self) -> Option<String> {
+        None
+    }
+
     fn capabilities(&self) -> Capabilities;
 
     fn status(&self) -> Result<Status>;

--- a/crates/scxtui/src/backend/mod.rs
+++ b/crates/scxtui/src/backend/mod.rs
@@ -22,12 +22,18 @@ pub type ModeArgs = Vec<(SchedMode, Vec<String>)>;
 
 /// What a given backend can actually do. The UI greys out or hides
 /// anything the active backend does not support.
+// Independent yes/no capability flags are the point of this struct;
+// `struct_excessive_bools` suggests a state machine, which this is not.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy)]
 pub struct Capabilities {
     /// Can switch schedulers at runtime without a service restart.
     pub live_switch: bool,
     /// Exposes per-scheduler mode configuration (`SchedulerModeArgs`).
     pub modes: bool,
+    /// Can start or switch a scheduler with free-form arguments instead
+    /// of a mode (`StartSchedulerWithArgs` / `SwitchSchedulerWithArgs`).
+    pub custom_args: bool,
     /// Supports restoring a configured default scheduler.
     pub restore_default: bool,
 }
@@ -88,6 +94,15 @@ pub trait SchedulerBackend {
     fn start(&self, sched: &str, mode: SchedMode) -> Result<()>;
 
     fn switch(&self, sched: &str, mode: SchedMode) -> Result<()>;
+
+    /// Starts `sched` with free-form arguments instead of a mode. The
+    /// arguments live only in the daemon's memory for this run — nothing
+    /// is written to the loader config, hence "session-only" in the UI.
+    fn start_with_args(&self, sched: &str, args: &[String]) -> Result<()>;
+
+    /// Same as [`Self::start_with_args`], but stops a running scheduler
+    /// first, like [`Self::switch`].
+    fn switch_with_args(&self, sched: &str, args: &[String]) -> Result<()>;
 
     fn stop(&self) -> Result<()>;
 

--- a/crates/scxtui/src/backend/mod.rs
+++ b/crates/scxtui/src/backend/mod.rs
@@ -16,13 +16,17 @@ pub mod service;
 use anyhow::Result;
 use scx_loader::SchedMode;
 
+/// Resolved arguments for every mode of one scheduler, in the daemon's
+/// stable order. Modes with no configured arguments carry an empty `Vec`.
+pub type ModeArgs = Vec<(SchedMode, Vec<String>)>;
+
 /// What a given backend can actually do. The UI greys out or hides
 /// anything the active backend does not support.
 #[derive(Debug, Clone, Copy)]
 pub struct Capabilities {
     /// Can switch schedulers at runtime without a service restart.
     pub live_switch: bool,
-    /// Exposes per-scheduler mode configuration (`SchedulerModes`).
+    /// Exposes per-scheduler mode configuration (`SchedulerModeArgs`).
     pub modes: bool,
     /// Supports restoring a configured default scheduler.
     pub restore_default: bool,
@@ -60,9 +64,14 @@ pub trait SchedulerBackend {
 
     fn supported_schedulers(&self) -> Result<Vec<String>>;
 
-    /// Modes that resolve to a non-empty argument list for `sched`.
-    /// `Auto` is always considered configured.
-    fn configured_modes(&self, sched: &str) -> Result<Vec<SchedMode>>;
+    /// Resolved arguments for every mode of `sched` (see [`ModeArgs`]).
+    /// This is a superset of the old "which modes are configured" query:
+    /// a mode counts as configured exactly when it is `Auto` or its
+    /// argument list here is non-empty — the same rule the daemon applies
+    /// in `SchedulerModes` — so callers derive that locally instead of
+    /// holding a second source of truth that could drift from the
+    /// arguments they display.
+    fn mode_args(&self, sched: &str) -> Result<ModeArgs>;
 
     fn start(&self, sched: &str, mode: SchedMode) -> Result<()>;
 

--- a/crates/scxtui/src/backend/service.rs
+++ b/crates/scxtui/src/backend/service.rs
@@ -223,6 +223,7 @@ impl SchedulerBackend for ServiceBackend {
         Capabilities {
             live_switch: false,
             modes: false,
+            custom_args: false,
             restore_default: false,
         }
     }
@@ -256,6 +257,17 @@ impl SchedulerBackend for ServiceBackend {
     fn mode_args(&self, _sched: &str) -> Result<ModeArgs> {
         // Unreachable in practice: `modes: false` keeps the UI from asking.
         Ok(Vec::new())
+    }
+
+    fn start_with_args(&self, _sched: &str, _args: &[String]) -> Result<()> {
+        // Unreachable in practice: `custom_args: false` keeps the UI from
+        // asking. scx.service knows only the persistent flags from its
+        // config file — the opposite of the session-only contract.
+        bail!("custom arguments are not supported by the scx.service backend")
+    }
+
+    fn switch_with_args(&self, _sched: &str, _args: &[String]) -> Result<()> {
+        bail!("custom arguments are not supported by the scx.service backend")
     }
 
     fn start(&self, sched: &str, _mode: SchedMode) -> Result<()> {

--- a/crates/scxtui/src/backend/service.rs
+++ b/crates/scxtui/src/backend/service.rs
@@ -21,7 +21,7 @@ use std::process::Command;
 use anyhow::{bail, Context, Result};
 use scx_loader::SchedMode;
 
-use super::{Capabilities, SchedulerBackend, Status};
+use super::{Capabilities, ModeArgs, SchedulerBackend, Status};
 
 const UNIT: &str = "scx.service";
 /// Debian/Arch convention first, Fedora/openSUSE second.
@@ -253,7 +253,8 @@ impl SchedulerBackend for ServiceBackend {
         Ok(scheds)
     }
 
-    fn configured_modes(&self, _sched: &str) -> Result<Vec<SchedMode>> {
+    fn mode_args(&self, _sched: &str) -> Result<ModeArgs> {
+        // Unreachable in practice: `modes: false` keeps the UI from asking.
         Ok(Vec::new())
     }
 

--- a/crates/scxtui/src/kernel.rs
+++ b/crates/scxtui/src/kernel.rs
@@ -31,16 +31,21 @@ impl KernelState {
 
     /// Whether `loader_name` (full name, e.g. `scx_lavd`) plausibly matches
     /// the ops the kernel reports. Ops names are chosen by each scheduler
-    /// and some embed extra detail — bpfland registers e.g.
-    /// `bpfland_1.1.2_x86_64_unknown_linux_gnu` — so beyond an exact match
-    /// (with or without the `scx_` prefix) an ops name that *starts with*
-    /// the scheduler name followed by `_` also counts. Used for a soft
-    /// warning only, so a rare false negative is acceptable.
+    /// and some embed extra detail, with or without the `scx_` prefix —
+    /// bpfland registers e.g. `bpfland_1.1.2_x86_64_unknown_linux_gnu`,
+    /// flow registers `scx_flow_3.1.1_x86_64_unknown_linux_gnu` — so
+    /// beyond an exact match (with or without the prefix) an ops name
+    /// that *starts with* either form of the scheduler name followed by
+    /// `_` also counts. Used for a soft warning only, so a rare false
+    /// negative is acceptable.
     pub fn matches(&self, loader_name: &str) -> bool {
         let stripped = loader_name.strip_prefix("scx_").unwrap_or(loader_name);
         self.ops.as_deref().is_some_and(|ops| {
             ops == loader_name
                 || ops == stripped
+                || ops
+                    .strip_prefix(loader_name)
+                    .is_some_and(|rest| rest.starts_with('_'))
                 || ops
                     .strip_prefix(stripped)
                     .is_some_and(|rest| rest.starts_with('_'))
@@ -91,6 +96,17 @@ mod tests {
     fn matches_versioned_ops_suffix() {
         // bpfland registers e.g. "bpfland_1.1.2_x86_64_unknown_linux_gnu".
         assert!(enabled_with(Some("bpfland_1.1.2_x86_64_unknown_linux_gnu")).matches("scx_bpfland"));
+    }
+
+    #[test]
+    fn matches_versioned_ops_suffix_with_prefix() {
+        // flow keeps the scx_ prefix in its versioned ops name.
+        assert!(enabled_with(Some("scx_flow_3.1.1_x86_64_unknown_linux_gnu")).matches("scx_flow"));
+    }
+
+    #[test]
+    fn rejects_full_name_prefix_without_separator() {
+        assert!(!enabled_with(Some("scx_flowmatic_1.0")).matches("scx_flow"));
     }
 
     #[test]

--- a/crates/scxtui/src/main.rs
+++ b/crates/scxtui/src/main.rs
@@ -3,6 +3,7 @@
 #![deny(unsafe_code)]
 
 mod app;
+mod args;
 mod backend;
 mod kernel;
 mod logs;

--- a/crates/scxtui/src/ui.rs
+++ b/crates/scxtui/src/ui.rs
@@ -107,7 +107,7 @@ fn draw_status_panel(frame: &mut Frame, app: &App, area: Rect) {
             Some(sched) if !status.args.is_empty() => {
                 lines.push(kv("State", "running", Color::Green));
                 lines.push(kv("Scheduler", strip_prefix(sched), Color::White));
-                lines.push(kv("Arguments", &status.args.join(" "), Color::White));
+                lines.push(kv("Arguments", &format_args(&status.args), Color::White));
             }
             Some(sched) => {
                 lines.push(kv("State", "running", Color::Green));

--- a/crates/scxtui/src/ui.rs
+++ b/crates/scxtui/src/ui.rs
@@ -11,7 +11,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
 use ratatui::Frame;
 
-use crate::app::{App, View};
+use crate::app::{App, ArgsInput, View};
 use crate::logs;
 
 const SCHED_PREFIX: &str = "scx_";
@@ -170,6 +170,21 @@ fn draw_status_panel(frame: &mut Frame, app: &App, area: Rect) {
         )));
     }
 
+    if let Some(input) = &app.args_input {
+        lines.push(Line::default());
+        let mut spans = vec![Span::styled(
+            "Args: ",
+            Style::default().add_modifier(Modifier::BOLD),
+        )];
+        spans.extend(input_spans(input));
+        lines.push(Line::from(spans));
+        lines.push(Line::from(Span::styled(
+            "  session-only — not written to the loader config; \
+same syntax as scxctl --args",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
     let panel = Paragraph::new(lines)
         .wrap(Wrap { trim: false })
         .block(Block::default().borders(Borders::ALL).title(" Status "));
@@ -310,11 +325,17 @@ fn draw_footer(frame: &mut Frame, app: &App, area: Rect) {
     .areas(area);
 
     let key_help = match app.view {
+        View::Schedulers if app.args_input.is_some() => {
+            String::from(" type arguments · Enter start/switch · Esc cancel")
+        }
         View::Schedulers => {
             let caps = app.capabilities();
             let mut help = String::from(" ↑/↓ select · Tab mode · Enter start");
             if caps.live_switch {
                 help.push_str("/switch");
+            }
+            if caps.custom_args {
+                help.push_str(" · a args");
             }
             help.push_str(" · s stop · r restart");
             if caps.restore_default {
@@ -364,6 +385,29 @@ fn strip_prefix(sched: &str) -> &str {
 
 fn mode_name(mode: scx_loader::SchedMode) -> &'static str {
     <&str>::from(mode)
+}
+
+/// Renders the field content with a reversed-video block as the cursor.
+/// A styled span instead of the real terminal cursor keeps the position
+/// correct under the paragraph's wrapping without any coordinate math;
+/// at the end of the buffer the block sits on a synthetic space.
+fn input_spans(input: &ArgsInput) -> Vec<Span<'static>> {
+    let mut before = String::new();
+    let mut at = None;
+    let mut after = String::new();
+    for (i, c) in input.buffer.chars().enumerate() {
+        match i.cmp(&input.cursor) {
+            std::cmp::Ordering::Less => before.push(c),
+            std::cmp::Ordering::Equal => at = Some(c),
+            std::cmp::Ordering::Greater => after.push(c),
+        }
+    }
+    let cursor = at.map_or_else(|| " ".to_owned(), |c| c.to_string());
+    vec![
+        Span::raw(before),
+        Span::styled(cursor, Style::default().add_modifier(Modifier::REVERSED)),
+        Span::raw(after),
+    ]
 }
 
 /// Formats an argument vector exactly like scxctl renders scheduler

--- a/crates/scxtui/src/ui.rs
+++ b/crates/scxtui/src/ui.rs
@@ -144,6 +144,19 @@ fn draw_status_panel(frame: &mut Frame, app: &App, area: Rect) {
             ),
             Span::raw("  (Tab to cycle)"),
         ]));
+        // Preview of what starting/switching in this mode would actually
+        // pass to the scheduler. Rendered only when the answer is known
+        // and non-empty: an unknown answer must not pretend to be "no
+        // arguments", and an empty one is covered by the note below (or,
+        // for Auto, by the scheduler's own defaults being the point).
+        // The surrounding paragraph wraps, so long flag lists fold instead
+        // of clipping.
+        if let Some(args) = app.selected_mode_args().filter(|args| !args.is_empty()) {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(format_args(args), Style::default().fg(Color::Gray)),
+            ]));
+        }
         if !app.selected_mode_configured() {
             lines.push(Line::from(Span::styled(
                 "  no configured arguments for this mode — scheduler defaults will be used",
@@ -351,4 +364,29 @@ fn strip_prefix(sched: &str) -> &str {
 
 fn mode_name(mode: scx_loader::SchedMode) -> &'static str {
     <&str>::from(mode)
+}
+
+/// Formats an argument vector exactly like scxctl renders scheduler
+/// arguments: `shell_words::join`, so token boundaries survive spaces,
+/// quotes and commas, and the rendered line parses back into the same
+/// vector via `shell_words::split`.
+fn format_args(args: &[String]) -> String {
+    shell_words::join(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Same guarantee scxctl pins for `format_scheduler_args`, repeated
+    /// here for the panel renderer: what the preview shows must parse
+    /// back into the identical argument vector.
+    #[test]
+    fn preview_format_round_trips() {
+        let args = ["--name", "foo bar", "", "a'b", "foo,bar"]
+            .map(str::to_string)
+            .to_vec();
+
+        assert_eq!(shell_words::split(&format_args(&args)), Ok(args));
+    }
 }


### PR DESCRIPTION
This series extends `scxtui`'s mode handling so users can see the arguments associated with a selected scheduler mode and optionally override them for the current session.

The backend now queries `SchedulerModeArgs` instead of maintaining a separate configured-mode view. Since the per-mode argument response is a strict superset of `SchedulerModes`, `scxtui` derives the configured-mode state locally using the same rule as `scx_loader`: `Auto` always counts as configured, while other modes count when their resolved argument list is non-empty.

Per-mode arguments are cached lazily per scheduler. Since `scx_loader` reads its configuration at startup, a successful answer remains valid for the daemon's lifetime. The cache is invalidated when the D-Bus owner changes, as well as on a manual refresh or backend switch, so an external daemon restart is handled without continuously re-querying unchanged configuration.

The selected mode's resolved arguments are now shown directly in the status panel. Both the mode preview and the running scheduler arguments use `shell_words::join`, matching `scxctl` and preserving token boundaries for arguments containing spaces, quotes, or commas.

Finally, `scxtui` gains a session-only custom-arguments field, opened with `a`. The entered arguments use the same parsing semantics as `scxctl --args` — comma splitting followed by shell-style word parsing — and are passed through `StartSchedulerWithArgs` or `SwitchSchedulerWithArgs`.

Custom arguments deliberately remain ephemeral: they affect only the current start/switch operation and are never written back to the loader configuration. The feature is exposed only by backends that advertise custom-argument support, leaving the `scx.service` backend behavior unchanged.