### PR TITLE
scx_loader: Add power-profiles-daemon support

### DIFF
--- a/configs/scx_loader.toml
+++ b/configs/scx_loader.toml
@@ -4,6 +4,14 @@
 # This field specifies the mode which will be used when scx_loader starts (e.g., on boot).
 #default_mode = "Auto"
 
+# Follow power-profiles-daemon and map its profiles to scx-loader modes.
+# The integration is disabled by default, and every mapping is optional.
+#[power_profiles]
+#enabled = true
+#power_saver = "PowerSave"
+#balanced = "Auto"
+#performance = "Gaming"
+
 # This "structure" allows configuring flags for each scheduler mode of particular scx scheduler
 #[scheds.'scheduler']
 #auto_mode = []

--- a/crates/scx_loader/configuration.md
+++ b/crates/scx_loader/configuration.md
@@ -21,6 +21,12 @@ The configuration file has the following structure:
 default_sched = "scx_cosmos"
 default_mode = "Auto"
 
+[power_profiles]
+enabled = true
+power_saver = "PowerSave"
+balanced = "Auto"
+performance = "Gaming"
+
 [scheds.scx_bpfland]
 auto_mode = ["-m", "auto"]
 gaming_mode = ["-m", "all"]
@@ -124,6 +130,16 @@ server_mode = []
 * This field specifies the default scheduler mode that will be used when starting a scheduler without explicitly specifying a mode.
 * Possible values are: `"Auto"`, `"Gaming"`, `"LowLatency"`, `"PowerSave"`, `"Server"`.
 * If this field is not present, it defaults to `"Auto"`.
+
+**`[power_profiles]`:**
+
+* `enabled` controls whether the normal D-Bus daemon follows power-profiles-daemon. It defaults to `false`; `scx_loader --auto` never follows PPD.
+* `power_saver`, `balanced`, and `performance` map PPD's `power-saver`, `balanced`, and `performance` profiles to scx-loader modes. Each mapping is optional and has no built-in default.
+* Mapping values use `"Auto"`, `"Gaming"`, `"PowerSave"`, `"LowLatency"`, or `"Server"`.
+* When enabled, scx-loader applies PPD's current profile at startup and after reconnecting, then reacts to profile changes.
+* A mapped event switches the currently running scheduler to the configured mode, replacing custom scheduler arguments. If no scheduler is running, the event is discarded.
+* Manual scheduler or mode changes remain active until the next mapped PPD event. Unmapped and unknown profiles leave the scheduler unchanged.
+* PPD may be absent or restart without preventing scx-loader from running; the monitor reconnects automatically.
 
 **`[scheds.scx_name]`:**
 

--- a/crates/scx_loader/src/config.rs
+++ b/crates/scx_loader/src/config.rs
@@ -21,7 +21,17 @@ use crate::SupportedSched;
 pub struct Config {
     pub default_sched: Option<SupportedSched>,
     pub default_mode: Option<SchedMode>,
+    pub power_profiles: PowerProfilesConfig,
     pub scheds: HashMap<String, Sched>,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PowerProfilesConfig {
+    pub enabled: bool,
+    pub power_saver: Option<SchedMode>,
+    pub balanced: Option<SchedMode>,
+    pub performance: Option<SchedMode>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
@@ -115,6 +125,7 @@ pub fn get_default_config() -> Config {
     Config {
         default_sched: None,
         default_mode: Some(SchedMode::Auto),
+        power_profiles: PowerProfilesConfig::default(),
         scheds: scheds_map,
     }
 }
@@ -521,5 +532,88 @@ server_mode = ["--profile", "gaming"]
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn test_power_profiles_config_defaults_to_disabled() {
+        let parsed_config =
+            parse_config_content("default_mode = \"Auto\"").expect("Failed to parse config");
+
+        assert_eq!(parsed_config.power_profiles, PowerProfilesConfig::default());
+    }
+
+    #[test]
+    fn test_partial_power_profiles_config() {
+        let config_str = r#"
+[power_profiles]
+enabled = true
+balanced = "Auto"
+"#;
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+
+        assert!(parsed_config.power_profiles.enabled);
+        assert_eq!(
+            parsed_config.power_profiles,
+            PowerProfilesConfig {
+                enabled: true,
+                power_saver: None,
+                balanced: Some(SchedMode::Auto),
+                performance: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_complete_power_profiles_config() {
+        let config_str = r#"
+[power_profiles]
+enabled = true
+power_saver = "PowerSave"
+balanced = "Auto"
+performance = "Gaming"
+"#;
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+
+        assert_eq!(
+            parsed_config.power_profiles,
+            PowerProfilesConfig {
+                enabled: true,
+                power_saver: Some(SchedMode::PowerSave),
+                balanced: Some(SchedMode::Auto),
+                performance: Some(SchedMode::Gaming),
+            }
+        );
+    }
+
+    #[test]
+    fn test_power_profiles_accepts_every_scheduler_mode() {
+        for (mode_name, expected_mode) in [
+            ("Auto", SchedMode::Auto),
+            ("Gaming", SchedMode::Gaming),
+            ("PowerSave", SchedMode::PowerSave),
+            ("LowLatency", SchedMode::LowLatency),
+            ("Server", SchedMode::Server),
+        ] {
+            let config_str = format!(
+                r#"
+[power_profiles]
+balanced = "{mode_name}"
+"#
+            );
+            let parsed_config =
+                parse_config_content(&config_str).expect("mode mapping should parse");
+
+            assert_eq!(parsed_config.power_profiles.balanced, Some(expected_mode));
+        }
+    }
+
+    #[test]
+    fn test_power_profiles_rejects_invalid_scheduler_mode() {
+        let config_str = r#"
+[power_profiles]
+balanced = "auto"
+"#;
+
+        assert!(parse_config_content(config_str).is_err());
     }
 }

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -10,6 +10,9 @@
 
 mod logger;
 
+#[cfg(test)]
+mod power_profiles;
+
 use scx_loader::dbus::LoaderClientProxy;
 use scx_loader::{config, SchedMode, SupportedSched};
 

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -9,8 +9,6 @@
 #![allow(clippy::cast_possible_wrap)]
 
 mod logger;
-
-#[cfg(test)]
 mod power_profiles;
 
 use scx_loader::dbus::LoaderClientProxy;
@@ -469,6 +467,17 @@ async fn main() -> Result<()> {
             .switch_scheduler(default_sched.clone(), default_mode)
             .await?;
     }
+
+    let _power_profiles_monitor = if config.power_profiles.enabled {
+        let monitor_connection = connection.clone();
+        let power_profiles_config = config.power_profiles.clone();
+
+        Some(tokio::spawn(async move {
+            power_profiles::monitor(monitor_connection, power_profiles_config).await;
+        }))
+    } else {
+        None
+    };
 
     // run worker/receiver loop
     worker_loop(config, rx).await?;

--- a/crates/scx_loader/src/main.rs
+++ b/crates/scx_loader/src/main.rs
@@ -468,6 +468,8 @@ async fn main() -> Result<()> {
             .await?;
     }
 
+    // Keep the monitor task handle bound in `main` so the runtime aborts the
+    // PPD monitor naturally when `worker_loop` exits and shuts down.
     let _power_profiles_monitor = if config.power_profiles.enabled {
         let monitor_connection = connection.clone();
         let power_profiles_config = config.power_profiles.clone();

--- a/crates/scx_loader/src/power_profiles.rs
+++ b/crates/scx_loader/src/power_profiles.rs
@@ -148,6 +148,7 @@ async fn monitor_session(connection: &Connection, config: &PowerProfilesConfig) 
         tokio::select! {
             changed = profile_changes.next() => {
                 let Some(changed) = changed else {
+                    log::warn!("PPD property change stream ended; reconnecting");
                     return Ok(());
                 };
                 let args = match changed.args() {
@@ -293,6 +294,10 @@ mod tests {
 
     #[test]
     fn retry_delay_caps_at_thirty_seconds() {
+        assert_eq!(
+            next_retry_delay(Duration::from_secs(15)),
+            Duration::from_secs(30)
+        );
         assert_eq!(
             next_retry_delay(Duration::from_secs(16)),
             Duration::from_secs(30)

--- a/crates/scx_loader/src/power_profiles.rs
+++ b/crates/scx_loader/src/power_profiles.rs
@@ -1,7 +1,74 @@
 // SPDX-License-Identifier: GPL-2.0
 
+use std::time::Duration;
+
+use anyhow::{Context, Result};
 use scx_loader::config::PowerProfilesConfig;
+use scx_loader::dbus::LoaderClientProxy;
 use scx_loader::SchedMode;
+use scx_loader::SupportedSched;
+use zbus::export::ordered_stream::OrderedStreamExt;
+use zbus::fdo::PropertiesProxy;
+use zbus::proxy::CacheProperties;
+use zbus::Connection;
+
+const PPD_SERVICE: &str = "org.freedesktop.UPower.PowerProfiles";
+const PPD_INTERFACE: &str = "org.freedesktop.UPower.PowerProfiles";
+const PPD_PATH: &str = "/org/freedesktop/UPower/PowerProfiles";
+
+#[zbus::proxy(
+    interface = "org.freedesktop.UPower.PowerProfiles",
+    default_service = "org.freedesktop.UPower.PowerProfiles",
+    default_path = "/org/freedesktop/UPower/PowerProfiles"
+)]
+trait PowerProfiles {
+    #[zbus(property)]
+    fn active_profile(&self) -> zbus::Result<String>;
+}
+
+async fn apply_profile(
+    loader: &LoaderClientProxy<'_>,
+    config: &PowerProfilesConfig,
+    profile: &str,
+) -> Result<()> {
+    let Some(mapped_mode) = resolve_mode(config, profile) else {
+        match profile {
+            "power-saver" | "balanced" | "performance" => {
+                log::debug!("No scx-loader mode is mapped for PPD profile {profile:?}");
+            }
+            _ => log::warn!("Ignoring unknown PPD profile {profile:?}"),
+        }
+        return Ok(());
+    };
+
+    let current_scheduler = loader
+        .current_scheduler()
+        .await
+        .context("Failed to query the current scheduler")?;
+    let current_mode = loader
+        .scheduler_mode()
+        .await
+        .context("Failed to query the current scheduler mode")?;
+    let current_args = loader
+        .current_scheduler_args()
+        .await
+        .context("Failed to query the current scheduler arguments")?;
+
+    if !should_apply(&current_scheduler, current_mode, &current_args, mapped_mode) {
+        return Ok(());
+    }
+
+    let scheduler = SupportedSched::try_from(current_scheduler.as_str())
+        .with_context(|| format!("Unsupported current scheduler {current_scheduler:?}"))?;
+    loader
+        .switch_scheduler(scheduler, mapped_mode)
+        .await
+        .with_context(|| {
+            format!("Failed to apply PPD profile {profile:?} as mode {mapped_mode:?}")
+        })?;
+
+    Ok(())
+}
 
 #[must_use]
 fn resolve_mode(config: &PowerProfilesConfig, profile: &str) -> Option<SchedMode> {
@@ -21,6 +88,112 @@ fn should_apply(
     mapped_mode: SchedMode,
 ) -> bool {
     current_scheduler != "unknown" && (current_mode != mapped_mode || !current_args.is_empty())
+}
+
+const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+#[must_use]
+const fn next_retry_delay(delay: Duration) -> Duration {
+    let doubled = delay.saturating_mul(2);
+    if doubled.as_secs() > MAX_RETRY_DELAY.as_secs() {
+        MAX_RETRY_DELAY
+    } else {
+        doubled
+    }
+}
+
+async fn monitor_session(connection: &Connection, config: &PowerProfilesConfig) -> Result<()> {
+    let power_profiles = PowerProfilesProxy::builder(connection)
+        .cache_properties(CacheProperties::No)
+        .build()
+        .await
+        .context("Failed to create the PPD proxy")?;
+    let loader = LoaderClientProxy::builder(connection)
+        .cache_properties(CacheProperties::No)
+        .build()
+        .await
+        .context("Failed to create the scx-loader proxy")?;
+    let properties = PropertiesProxy::builder(connection)
+        .destination(PPD_SERVICE)
+        .context("Invalid PPD service name")?
+        .path(PPD_PATH)
+        .context("Invalid PPD object path")?
+        .build()
+        .await
+        .context("Failed to create the PPD properties proxy")?;
+
+    let mut profile_changes = properties
+        .receive_properties_changed()
+        .await
+        .context("Failed to subscribe to PPD property changes")?;
+    let mut owner_changes = power_profiles
+        .inner()
+        .receive_owner_changed()
+        .await
+        .context("Failed to subscribe to PPD owner changes")?;
+
+    let active_profile = power_profiles
+        .active_profile()
+        .await
+        .context("Failed to read PPD's active profile")?;
+    if let Err(error) = apply_profile(&loader, config, &active_profile).await {
+        log::warn!("Failed to process PPD profile {active_profile:?}: {error:#}");
+    }
+
+    loop {
+        tokio::select! {
+            changed = profile_changes.next() => {
+                let Some(changed) = changed else {
+                    return Ok(());
+                };
+                let args = match changed.args() {
+                    Ok(args) => args,
+                    Err(error) => {
+                        log::warn!("Failed to decode PPD property changes: {error}");
+                        continue;
+                    }
+                };
+                let active_profile_changed = args.interface_name().as_str() == PPD_INTERFACE
+                    && (args.changed_properties().contains_key("ActiveProfile")
+                        || args
+                            .invalidated_properties()
+                            .contains(&"ActiveProfile"));
+                if !active_profile_changed {
+                    continue;
+                }
+
+                match power_profiles.active_profile().await {
+                    Ok(profile) => {
+                        if let Err(error) = apply_profile(&loader, config, &profile).await {
+                            log::warn!("Failed to process PPD profile {profile:?}: {error:#}");
+                        }
+                    }
+                    Err(error) => log::warn!("Failed to read changed PPD profile: {error}"),
+                }
+            }
+            _ = owner_changes.next() => return Ok(()),
+        }
+    }
+}
+
+pub(crate) async fn monitor(connection: Connection, config: PowerProfilesConfig) {
+    let mut retry_delay = INITIAL_RETRY_DELAY;
+
+    loop {
+        match monitor_session(&connection, &config).await {
+            Ok(()) => {
+                retry_delay = INITIAL_RETRY_DELAY;
+                log::warn!("PPD connection changed; reconnecting");
+            }
+            Err(error) => {
+                log::warn!("PPD monitoring unavailable: {error:#}; retrying in {retry_delay:?}");
+            }
+        }
+
+        tokio::time::sleep(retry_delay).await;
+        retry_delay = next_retry_delay(retry_delay);
+    }
 }
 
 #[cfg(test)]
@@ -105,5 +278,25 @@ mod tests {
             &[],
             SchedMode::PowerSave
         ));
+    }
+
+    #[test]
+    fn retry_delay_doubles() {
+        assert_eq!(
+            next_retry_delay(Duration::from_secs(1)),
+            Duration::from_secs(2)
+        );
+    }
+
+    #[test]
+    fn retry_delay_caps_at_thirty_seconds() {
+        assert_eq!(
+            next_retry_delay(Duration::from_secs(16)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            next_retry_delay(Duration::from_secs(30)),
+            Duration::from_secs(30)
+        );
     }
 }

--- a/crates/scx_loader/src/power_profiles.rs
+++ b/crates/scx_loader/src/power_profiles.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use scx_loader::config::PowerProfilesConfig;
+use scx_loader::SchedMode;
+
+#[must_use]
+fn resolve_mode(config: &PowerProfilesConfig, profile: &str) -> Option<SchedMode> {
+    match profile {
+        "power-saver" => config.power_saver,
+        "balanced" => config.balanced,
+        "performance" => config.performance,
+        _ => None,
+    }
+}
+
+#[must_use]
+fn should_apply(
+    current_scheduler: &str,
+    current_mode: SchedMode,
+    current_args: &[String],
+    mapped_mode: SchedMode,
+) -> bool {
+    current_scheduler != "unknown" && (current_mode != mapped_mode || !current_args.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mappings() -> PowerProfilesConfig {
+        PowerProfilesConfig {
+            enabled: true,
+            power_saver: Some(SchedMode::PowerSave),
+            balanced: Some(SchedMode::Auto),
+            performance: Some(SchedMode::Gaming),
+        }
+    }
+
+    #[test]
+    fn resolves_each_known_profile() {
+        let config = mappings();
+
+        assert_eq!(
+            resolve_mode(&config, "power-saver"),
+            Some(SchedMode::PowerSave)
+        );
+        assert_eq!(resolve_mode(&config, "balanced"), Some(SchedMode::Auto));
+        assert_eq!(
+            resolve_mode(&config, "performance"),
+            Some(SchedMode::Gaming)
+        );
+    }
+
+    #[test]
+    fn omitted_mapping_resolves_to_no_action() {
+        let config = PowerProfilesConfig {
+            enabled: true,
+            balanced: Some(SchedMode::Server),
+            ..PowerProfilesConfig::default()
+        };
+
+        assert_eq!(resolve_mode(&config, "power-saver"), None);
+    }
+
+    #[test]
+    fn unknown_profile_resolves_to_no_action() {
+        assert_eq!(resolve_mode(&mappings(), "future-profile"), None);
+    }
+
+    #[test]
+    fn skips_when_no_scheduler_is_running() {
+        assert!(!should_apply(
+            "unknown",
+            SchedMode::Auto,
+            &[],
+            SchedMode::Gaming
+        ));
+    }
+
+    #[test]
+    fn skips_same_mode_without_custom_arguments() {
+        assert!(!should_apply(
+            "scx_lavd",
+            SchedMode::Gaming,
+            &[],
+            SchedMode::Gaming
+        ));
+    }
+
+    #[test]
+    fn applies_same_reported_mode_when_custom_arguments_are_active() {
+        assert!(should_apply(
+            "scx_lavd",
+            SchedMode::Auto,
+            &["--performance".to_owned()],
+            SchedMode::Auto
+        ));
+    }
+
+    #[test]
+    fn applies_a_different_mapped_mode() {
+        assert!(should_apply(
+            "scx_lavd",
+            SchedMode::Auto,
+            &[],
+            SchedMode::PowerSave
+        ));
+    }
+}

--- a/crates/scx_loader/src/power_profiles.rs
+++ b/crates/scx_loader/src/power_profiles.rs
@@ -96,7 +96,10 @@ const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
 #[must_use]
 const fn next_retry_delay(delay: Duration) -> Duration {
     let doubled = delay.saturating_mul(2);
-    if doubled.as_secs() > MAX_RETRY_DELAY.as_secs() {
+    if doubled.as_secs() > MAX_RETRY_DELAY.as_secs()
+        || (doubled.as_secs() == MAX_RETRY_DELAY.as_secs()
+            && doubled.subsec_nanos() > MAX_RETRY_DELAY.subsec_nanos())
+    {
         MAX_RETRY_DELAY
     } else {
         doubled
@@ -296,6 +299,14 @@ mod tests {
         );
         assert_eq!(
             next_retry_delay(Duration::from_secs(30)),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn retry_delay_caps_doubled_subsecond_remainder() {
+        assert_eq!(
+            next_retry_delay(Duration::from_secs(15) + Duration::from_nanos(1)),
             Duration::from_secs(30)
         );
     }


### PR DESCRIPTION
This PR adds a monitor for PPD dbus messages,  PPD-based mode-swiitch, and a new config section. The config section allows enabling the feature, and setting what scx_loader modes should correspond to each PPD profile:

```
[power_profiles]
enabled = true
power_saver = "PowerSave"
balanced = "Auto"
performance = "Gaming"
```

On start, we read the active profile and set the mode accordingly. From then on, any profile change will be received and mapped to corresponding scx_loader mode switch.

Resolves #67 